### PR TITLE
Use Salesforce to read data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ __pycache__
 .envrc
 
 data/mailchimp.csv
-data/result.csv
+data/result*.csv
 data/salesforce.csv

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,1 @@
+sqlalchemy<2

--- a/default.lock
+++ b/default.lock
@@ -6,7 +6,7 @@
 // {
 //   "version": 3,
 //   "valid_for_interpreter_constraints": [
-//     "CPython>=3.9"
+//     "CPython>=3.10"
 //   ],
 //   "generated_with_requirements": [
 //     "cryptography",
@@ -14,10 +14,13 @@
 //     "pydantic",
 //     "pytest",
 //     "python-Levenshtein",
+//     "simple-salesforce",
 //     "uszipcode"
 //   ],
 //   "manylinux": "manylinux2014",
-//   "requirement_constraints": [],
+//   "requirement_constraints": [
+//     "sqlalchemy<2"
+//   ],
 //   "only_binary": [],
 //   "no_binary": []
 // }
@@ -28,7 +31,9 @@
   "allow_prereleases": false,
   "allow_wheels": true,
   "build_isolation": true,
-  "constraints": [],
+  "constraints": [
+    "sqlalchemy<2"
+  ],
   "locked_resolves": [
     {
       "locked_requirements": [
@@ -36,13 +41,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "0641064de18ba7a25dee8f96403ebc39113d0cb953a01429249d5c7564666a43",
-              "url": "https://files.pythonhosted.org/packages/28/78/d31230046e58c207284c6b2c4e8d96e6d3cb4e52354721b944d3e1ee4aa5/annotated_types-0.6.0-py3-none-any.whl"
+              "hash": "1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53",
+              "url": "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "563339e807e53ffd9c267e99fc6d9ea23eb8443c08f112651963e24e22f84a5d",
-              "url": "https://files.pythonhosted.org/packages/67/fe/8c7b275824c6d2cd17c93ee85d0ee81c090285b6d52f4876ccc47cf9c3c4/annotated_types-0.6.0.tar.gz"
+              "hash": "aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89",
+              "url": "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz"
             }
           ],
           "project_name": "annotated-types",
@@ -50,7 +55,7 @@
             "typing-extensions>=4.0.0; python_version < \"3.9\""
           ],
           "requires_python": ">=3.8",
-          "version": "0.6.0"
+          "version": "0.7.0"
         },
         {
           "artifacts": [
@@ -110,26 +115,26 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1",
-              "url": "https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl"
+              "hash": "ddc6c8ce995e6987e7faf5e3f1b02b302836a0e5d98ece18392cb1a36c72ad56",
+              "url": "https://files.pythonhosted.org/packages/5b/11/1e78951465b4a225519b8c3ad29769c49e0d8d157a070f681d5b6d64737f/certifi-2024.6.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f",
-              "url": "https://files.pythonhosted.org/packages/71/da/e94e26401b62acd6d91df2b52954aceb7f561743aa5ccc32152886c76c96/certifi-2024.2.2.tar.gz"
+              "hash": "3cd43f1c6fa7dedc5899d69d3ad0398fd018ad1a17fba83ddaf78aa46c747516",
+              "url": "https://files.pythonhosted.org/packages/07/b3/e02f4f397c81077ffc52a538e0aec464016f1860c472ed33bd2a1d220cc5/certifi-2024.6.2.tar.gz"
             }
           ],
           "project_name": "certifi",
           "requires_dists": [],
           "requires_python": ">=3.6",
-          "version": "2024.2.2"
+          "version": "2024.6.2"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8895613bcc094d4a1b2dbe179d88d7fb4a15cee43c052e8885783fac397d91fe",
-              "url": "https://files.pythonhosted.org/packages/8c/54/82aa3c014760d5a6ddfde3253602f0ac1937dd504621d4139746f230a7b5/cffi-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "2d92b25dbf6cae33f65005baf472d2c245c050b1ce709cc4588cdcdd5495b520",
+              "url": "https://files.pythonhosted.org/packages/4c/00/e17e2a8df0ff5aca2edd9eeebd93e095dd2515f2dd8d591d84a3233518f6/cffi-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -143,16 +148,6 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "b29ebffcf550f9da55bec9e02ad430c992a87e5f512cd63388abb76f1036d8d2",
-              "url": "https://files.pythonhosted.org/packages/20/3b/f95e667064141843843df8ca79dd49ba57bb7a7615d6d7d538531e45f002/cffi-1.16.0-cp39-cp39-macosx_11_0_arm64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "748dcd1e3d3d7cd5443ef03ce8685043294ad6bd7c02a38d1bd367cfd968e000",
-              "url": "https://files.pythonhosted.org/packages/20/f8/5931cfb7a8cc15d224099cead5e5432efe729bd61abce72d9b3e51e5800b/cffi-1.16.0-cp39-cp39-musllinux_1_1_i686.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "fa3a0128b152627161ce47201262d3140edb5a5c3da88d73a1b790a959126956",
               "url": "https://files.pythonhosted.org/packages/22/04/1d10d5baf3faaae9b35f6c49bcf25c1be81ea68cc7ee6923206d02be85b0/cffi-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl"
             },
@@ -163,11 +158,6 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "dc9b18bf40cc75f66f40a7379f6a9513244fe33c0e8aa72e2d56b0196a7ef872",
-              "url": "https://files.pythonhosted.org/packages/33/14/8398798ab001523f1abb2b4170a01bf2114588f3f1fa1f984b3f3bef107e/cffi-1.16.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "e70f54f1796669ef691ca07d046cd81a29cb4deb1e5f942003f401c0c4a2695d",
               "url": "https://files.pythonhosted.org/packages/36/44/124481b75d228467950b9e81d20ec963f33517ca551f08956f2838517ece/cffi-1.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
@@ -175,16 +165,6 @@
               "algorithm": "sha256",
               "hash": "e09f3ff613345df5e8c3667da1d918f9149bd623cd9070c983c013792a9a62eb",
               "url": "https://files.pythonhosted.org/packages/47/e3/b6832b1b9a1b6170c585ee2c2d30baf64d0a497c17e6623f42cfeb59c114/cffi-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "2d92b25dbf6cae33f65005baf472d2c245c050b1ce709cc4588cdcdd5495b520",
-              "url": "https://files.pythonhosted.org/packages/4c/00/e17e2a8df0ff5aca2edd9eeebd93e095dd2515f2dd8d591d84a3233518f6/cffi-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "9cb4a35b3642fc5c005a6755a5d17c6c8b6bcb6981baf81cea8bfbc8903e8ba8",
-              "url": "https://files.pythonhosted.org/packages/50/bd/17a8f9ac569d328de304e7318d7707fcdb6f028bcc194d80cfc654902007/cffi-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
@@ -208,11 +188,6 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "b86851a328eedc692acf81fb05444bdf1891747c25af7529e39ddafaf68a4f3f",
-              "url": "https://files.pythonhosted.org/packages/69/46/8882b0405be4ac7db3fefa5a201f221acb54f27c76e584e23e9c62b68819/cffi-1.16.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "b84834d0cf97e7d27dd5b7f3aca7b6e9263c56308ab9dc8aae9784abb774d404",
               "url": "https://files.pythonhosted.org/packages/95/c8/ce05a6cba2bec12d4b28285e66c53cc88dd7385b102dea7231da3b74cfef/cffi-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl"
             },
@@ -228,11 +203,6 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "582215a0e9adbe0e379761260553ba11c58943e4bbe9c36430c4ca6ac74b15ed",
-              "url": "https://files.pythonhosted.org/packages/9d/da/e6dbf22b66899419e66c501ae5f1cf3d69979d4c75ad30da683f60abba94/cffi-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "b7be2d771cdba2942e13215c4e340bfd76398e9227ad10402a8767ab1865d2e6",
               "url": "https://files.pythonhosted.org/packages/a3/81/5f5d61338951afa82ce4f0f777518708893b9420a8b309cc037fbf114e63/cffi-1.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
@@ -240,11 +210,6 @@
               "algorithm": "sha256",
               "hash": "6b3d6606d369fc1da4fd8c357d026317fbb9c9b75d36dc16e90e84c26854b088",
               "url": "https://files.pythonhosted.org/packages/aa/aa/1c43e48a6f361d1529f9e4602d6992659a0107b5f21cae567e2eddcf8d66/cffi-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "c0f31130ebc2d37cdd8e44605fb5fa7ad59049298b3f745c74fa74c62fbfcfc4",
-              "url": "https://files.pythonhosted.org/packages/ae/00/831d01e63288d1654ed3084a6ac8b0940de6dc0ada4ba71b830fff7a0088/cffi-1.16.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
@@ -285,11 +250,6 @@
               "algorithm": "sha256",
               "hash": "88e2b3c14bdb32e440be531ade29d3c50a1a59cd4e51b1dd8b0865c54ea5d2e2",
               "url": "https://files.pythonhosted.org/packages/e4/c7/c09cc6fd1828ea950e60d44e0ef5ed0b7e3396fbfb856e49ca7d629b1408/cffi-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "8f8e709127c6c77446a8c0a8c8bf3c8ee706a06cd44b1e827c3e6a2ee6b8c098",
-              "url": "https://files.pythonhosted.org/packages/ea/ac/e9e77bc385729035143e54cc8c4785bd480eaca9df17565963556b0b7a93/cffi-1.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -348,18 +308,8 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185",
-              "url": "https://files.pythonhosted.org/packages/1f/8d/33c860a7032da5b93382cbe2873261f81467e7b37f4ed91e25fed62fd49b/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143",
               "url": "https://files.pythonhosted.org/packages/24/9d/2e3ef673dfd5be0154b20363c5cdcc5606f35666544381bee15af3778239/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_s390x.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0",
-              "url": "https://files.pythonhosted.org/packages/2a/9d/a6d15bd1e3e2914af5955c8eb15f4071997e7078419328fee93dfd497eb7/charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
@@ -388,11 +338,6 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269",
-              "url": "https://files.pythonhosted.org/packages/3d/85/5b7416b349609d20611a64718bed383b9251b5a601044550f0c8983b8900/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96",
               "url": "https://files.pythonhosted.org/packages/3e/33/21a875a61057165e92227466e54ee076b73af1e21fe1b31f1e292251aa1e/charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl"
             },
@@ -413,11 +358,6 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519",
-              "url": "https://files.pythonhosted.org/packages/44/80/b339237b4ce635b4af1c73742459eee5f97201bd92b2371c53e11958392e/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26",
               "url": "https://files.pythonhosted.org/packages/45/59/3d27019d3b447a88fe7e7d004a1e04be220227760264cc41b405e863891b/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_aarch64.whl"
             },
@@ -425,21 +365,6 @@
               "algorithm": "sha256",
               "hash": "9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03",
               "url": "https://files.pythonhosted.org/packages/46/6a/d5c26c41c49b546860cc1acabdddf48b0b3fb2685f4f5617ac59261b44ae/charset_normalizer-3.3.2-cp310-cp310-macosx_11_0_arm64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458",
-              "url": "https://files.pythonhosted.org/packages/51/fd/0ee5b1c2860bb3c60236d05b6e4ac240cf702b67471138571dad91bcfed8/charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_i686.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8",
-              "url": "https://files.pythonhosted.org/packages/53/cd/aa4b8a4d82eeceb872f83237b2d27e43e637cac9ffaef19a1321c3bafb67/charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_s390x.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561",
-              "url": "https://files.pythonhosted.org/packages/54/7f/cad0b328759630814fcf9d804bfabaf47776816ad4ef2e9938b7e1123d04/charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -458,11 +383,6 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d",
-              "url": "https://files.pythonhosted.org/packages/66/fe/c7d3da40a66a6bf2920cce0f436fa1f62ee28aaf92f412f0bf3b84c8ad6c/charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db",
               "url": "https://files.pythonhosted.org/packages/68/77/02839016f6fbbf808e8b38601df6e0e66c17bbab76dff4613f7511413597/charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl"
             },
@@ -478,11 +398,6 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c",
-              "url": "https://files.pythonhosted.org/packages/79/66/8946baa705c588521afe10b2d7967300e49380ded089a62d38537264aece/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d",
               "url": "https://files.pythonhosted.org/packages/7b/ef/5eb105530b4da8ae37d506ccfa25057961b7b63d581def6f99165ea89c7e/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_i686.whl"
             },
@@ -490,11 +405,6 @@
               "algorithm": "sha256",
               "hash": "a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389",
               "url": "https://files.pythonhosted.org/packages/91/33/749df346e93d7a30cdcb90cbfdd41a06026317bfbfb62cd68307c1a3c543/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796",
-              "url": "https://files.pythonhosted.org/packages/98/69/5d8751b4b670d623aa7a47bef061d69c279e9f922f6705147983aa76c3ce/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -515,11 +425,6 @@
               "algorithm": "sha256",
               "hash": "6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d",
               "url": "https://files.pythonhosted.org/packages/b8/60/e2f67915a51be59d4539ed189eb0a2b0d292bf79270410746becb32bc2c3/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c",
-              "url": "https://files.pythonhosted.org/packages/c2/65/52aaf47b3dd616c11a19b1052ce7fa6321250a7a0b975f48d8c366733b9f/charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
@@ -558,11 +463,6 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2",
-              "url": "https://files.pythonhosted.org/packages/e1/9c/60729bf15dc82e3aaf5f71e81686e42e50715a1399770bcde1a9e43d09db/charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_ppc64le.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f",
               "url": "https://files.pythonhosted.org/packages/e4/a6/7ee57823d46331ddc37dd00749c95b0edec2c79b15fc0d6e6efb532e89ac/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
@@ -580,11 +480,6 @@
               "algorithm": "sha256",
               "hash": "cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6",
               "url": "https://files.pythonhosted.org/packages/f6/93/bb6cbeec3bf9da9b2eba458c15966658d1daa8b982c642f81c93ad9b40e1/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4",
-              "url": "https://files.pythonhosted.org/packages/f7/9d/bcf4a449a438ed6f19790eee543a86a740c77508fbc5ddab210ab3ba3a9a/charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl"
             }
           ],
           "project_name": "charset-normalizer",
@@ -596,133 +491,118 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c65f96dad14f8528a447414125e1fc8feb2ad5a272b8f68477abbcc1ea7d94b9",
-              "url": "https://files.pythonhosted.org/packages/47/f9/3a73439e4a3873ed2b5ffed9aa1361b3db2cf8f462c5c926e556b50c9c7b/cryptography-42.0.7-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl"
+              "hash": "c9bb2ae11bfbab395bdd072985abde58ea9860ed84e59dbc0463a5d0159f5b71",
+              "url": "https://files.pythonhosted.org/packages/c1/e2/60b05e720766e185ef097d07068bd878a51d613ef91e4c241750f9c9192b/cryptography-42.0.8-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1a58839984d9cb34c855197043eaae2c187d930ca6d644612843b4fe8513c886",
-              "url": "https://files.pythonhosted.org/packages/0a/8b/2a41805540e49df1ea053f0dfef0340964fe422d61f6e398d16bf6c4013b/cryptography-42.0.7-cp39-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "6b7c4f03ce01afd3b76cf69a5455caa9cfa3de8c8f493e0d3ab7d20611c8dae9",
+              "url": "https://files.pythonhosted.org/packages/07/40/d6f6819c62e808ea74639c3c640f7edd636b86cce62cb14943996a15df92/cryptography-42.0.8-cp37-abi3-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e9b2a6309f14c0497f348d08a065d52f3020656f675819fc405fb63bbcd26562",
-              "url": "https://files.pythonhosted.org/packages/2b/e5/2220313802146732cf885f5bdf903d7d9075d9771fcbda9c9756f708e76e/cryptography-42.0.7-pp39-pypy39_pp73-macosx_10_12_x86_64.whl"
+              "hash": "cafb92b2bc622cd1aa6a1dce4b93307792633f4c5fe1f46c6b97cf67073ec961",
+              "url": "https://files.pythonhosted.org/packages/0f/38/85c74d0ac4c540780e072b1e6f148ecb718418c1062edcb20d22f3ec5bbb/cryptography-42.0.8-cp39-abi3-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2954fccea107026512b15afb4aa664a5640cd0af630e2ee3962f2602693f0c82",
-              "url": "https://files.pythonhosted.org/packages/39/56/45e7db74b8bd14e32238a7709c94fd40dbe9a38dccec6afb43afcc6cad84/cryptography-42.0.7-pp310-pypy310_pp73-macosx_10_12_x86_64.whl"
+              "hash": "ad803773e9df0b92e0a817d22fd8a3675493f690b96130a5e24f1b8fabbea9c7",
+              "url": "https://files.pythonhosted.org/packages/25/c9/86f04e150c5d5d5e4a731a2c1e0e43da84d901f388e3fea3d5de98d689a7/cryptography-42.0.8-cp37-abi3-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2e47577f9b18723fa294b0ea9a17d5e53a227867a0a4904a1a076d1646d45ca1",
-              "url": "https://files.pythonhosted.org/packages/45/df/f2f6cc5124fb85ff84615d62b996997b22a1c7c37a5ff3f5e8907a5ffa86/cryptography-42.0.7-cp39-abi3-musllinux_1_2_aarch64.whl"
+              "hash": "e599b53fd95357d92304510fb7bda8523ed1f79ca98dce2f43c115950aa78801",
+              "url": "https://files.pythonhosted.org/packages/35/66/2d87e9ca95c82c7ee5f2c09716fc4c4242c1ae6647b9bd27e55e920e9f10/cryptography-42.0.8-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4f698edacf9c9e0371112792558d2f705b5645076cc0aaae02f816a0171770fd",
-              "url": "https://files.pythonhosted.org/packages/4d/21/aa22aedd528839c09cf867b02124ff41109859c80c1bf18b9de342157f95/cryptography-42.0.7-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl"
+              "hash": "c4783183f7cb757b73b2ae9aed6599b96338eb957233c58ca8f49a49cc32fd5e",
+              "url": "https://files.pythonhosted.org/packages/43/c2/4a3eef67e009a522711ebd8ac89424c3a7fe591ece7035d964419ad52a1d/cryptography-42.0.8-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bd13b5e9b543532453de08bcdc3cc7cebec6f9883e886fd20a92f26940fd3e7a",
-              "url": "https://files.pythonhosted.org/packages/53/f7/25186f6ef7df5dc1883ceee11f20305749a7f49ee4066a21818cbe67514e/cryptography-42.0.7-cp37-abi3-macosx_10_12_x86_64.whl"
+              "hash": "a0608251135d0e03111152e41f0cc2392d1e74e35703960d4190b2e0f4ca9c70",
+              "url": "https://files.pythonhosted.org/packages/49/1c/9f6d13cc8041c05eebff1154e4e71bedd1db8e174fff999054435994187a/cryptography-42.0.8-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e6b8f1881dac458c34778d0a424ae5769de30544fc678eac51c1c8bb2183e9da",
-              "url": "https://files.pythonhosted.org/packages/55/12/6cdd1914e3b443f10f27c1b249cbdab0134962c3cfce25f1b4ae2d087ebf/cryptography-42.0.7-cp37-abi3-musllinux_1_2_aarch64.whl"
+              "hash": "2f66d9cd9147ee495a8374a45ca445819f8929a3efcd2e3df6428e46c3cbb10b",
+              "url": "https://files.pythonhosted.org/packages/53/c2/903014dafb7271fb148887d4355b2e90319cad6e810663be622b0c933fc9/cryptography-42.0.8-cp37-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "31adb7d06fe4383226c3e963471f6837742889b3c4caa55aac20ad951bc8ffda",
-              "url": "https://files.pythonhosted.org/packages/61/fc/bc9d580e480741c05fc6df6f9774dfe33ae42905361661d5d2616476bb62/cryptography-42.0.7-cp39-abi3-manylinux_2_28_aarch64.whl"
+              "hash": "2346b911eb349ab547076f47f2e035fc8ff2c02380a7cbbf8d87114fa0f1c583",
+              "url": "https://files.pythonhosted.org/packages/5c/46/de71d48abf2b6d3c808f4fbb0f4dc44a4e72786be23df0541aa2a3f6fd7e/cryptography-42.0.8-cp37-abi3-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "02c0eee2d7133bdbbc5e24441258d5d2244beb31da5ed19fbb80315f4bbbff55",
-              "url": "https://files.pythonhosted.org/packages/64/0c/36f71286fef9987f0e850f9b9a78a41784fe7f66c3b7611530b6bb0ecec4/cryptography-42.0.7-cp37-abi3-manylinux_2_28_aarch64.whl"
+              "hash": "e3ec3672626e1b9e55afd0df6d774ff0e953452886e06e0f1eb7eb0c832e8902",
+              "url": "https://files.pythonhosted.org/packages/5d/32/f6326c70a9f0f258a201d3b2632bca586ea24d214cec3cf36e374040e273/cryptography-42.0.8-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ecbfbc00bf55888edda9868a4cf927205de8499e7fabe6c050322298382953f2",
-              "url": "https://files.pythonhosted.org/packages/78/63/66c03eb51f0d241862083deb3f17ab5fce08cf6b347db7887bcb4d1a194e/cryptography-42.0.7.tar.gz"
+              "hash": "dc0fdf6787f37b1c6b08e6dfc892d9d068b5bdb671198c72072828b80bd5fe4c",
+              "url": "https://files.pythonhosted.org/packages/5f/f9/c3d4f19b82bdb25a3d857fe96e7e571c981810e47e3f299cc13ac429066a/cryptography-42.0.8-cp39-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0d563795db98b4cd57742a78a288cdbdc9daedac29f2239793071fe114f13785",
-              "url": "https://files.pythonhosted.org/packages/79/fd/4525835d3e42e2db30169d42215ce74762f447fcbf01ed02f74f59bd74cb/cryptography-42.0.7-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "dea567d1b0e8bc5764b9443858b673b734100c2871dc93163f58c46a97a83d28",
+              "url": "https://files.pythonhosted.org/packages/60/12/f064af29190cdb1d38fe07f3db6126091639e1dece7ec77c4ff037d49193/cryptography-42.0.8-cp39-abi3-macosx_10_12_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "efd0bf5205240182e0f13bcaea41be4fdf5c22c5129fc7ced4a0282ac86998c9",
-              "url": "https://files.pythonhosted.org/packages/7b/4e/fa4896744259ee8602464ed2c7330b736cc4dd3fd92f63cd56828bf36707/cryptography-42.0.7-cp39-abi3-manylinux_2_28_x86_64.whl"
+              "hash": "31f721658a29331f895a5a54e7e82075554ccfb8b163a18719d342f5ffe5ecb1",
+              "url": "https://files.pythonhosted.org/packages/89/f4/a8b982e88eb5350407ebdbf4717b55043271d878705329e107f4783555f2/cryptography-42.0.8-cp39-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "779245e13b9a6638df14641d029add5dc17edbef6ec915688f3acb9e720a5858",
-              "url": "https://files.pythonhosted.org/packages/80/91/762c76c55db47cb94e1ba91ec6734a4f1e64466cbef5ef8cd63c5ab4f31c/cryptography-42.0.7-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "8d09d05439ce7baa8e9e95b07ec5b6c886f548deb7e0f69ef25f64b3bce842f2",
+              "url": "https://files.pythonhosted.org/packages/93/a7/1498799a2ea06148463a9a2c10ab2f6a921a74fb19e231b27dc412a748e2/cryptography-42.0.8.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "5e44507bf8d14b36b8389b226665d597bc0f18ea035d75b4e53c7b1ea84583cc",
-              "url": "https://files.pythonhosted.org/packages/81/17/0294e576979d7f388855bf64b3cc6d9fc08168cdf6833ff0df3ad0ee6580/cryptography-42.0.7-cp37-abi3-manylinux_2_28_x86_64.whl"
+              "hash": "d45b940883a03e19e944456a558b67a41160e367a719833c53de6911cabba2b7",
+              "url": "https://files.pythonhosted.org/packages/95/26/82d704d988a193cbdc69ac3b41c687c36eaed1642cce52530ad810c35645/cryptography-42.0.8-cp37-abi3-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "362e7197754c231797ec45ee081f3088a27a47c6c01eff2ac83f60f85a50fe60",
-              "url": "https://files.pythonhosted.org/packages/a8/0f/35ffbbc42db7e61af62298ed057ac43fb958025f5191ce9720e6b8bc4127/cryptography-42.0.7-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl"
+              "hash": "fff12c88a672ab9c9c1cf7b0c80e3ad9e2ebd9d828d955c126be4fd3e5578c9e",
+              "url": "https://files.pythonhosted.org/packages/a2/68/e16751f6b859bc120f53fddbf3ebada5c34f0e9689d8af32884d8b2e4b4c/cryptography-42.0.8-cp39-abi3-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a987f840718078212fdf4504d0fd4c6effe34a7e4740378e59d47696e8dfb477",
-              "url": "https://files.pythonhosted.org/packages/aa/b5/57982a4ca3542daeabee2303263a8b9d59968d47a1977a36f6aa9344e32e/cryptography-42.0.7-cp37-abi3-macosx_10_12_universal2.whl"
+              "hash": "ba4f0a211697362e89ad822e667d8d340b4d8d55fae72cdd619389fb5912eefe",
+              "url": "https://files.pythonhosted.org/packages/a3/fe/1e21699f0a7904e8a30d4fc6db262958f1edf5e505a02e7d97a5b419e482/cryptography-42.0.8-pp310-pypy310_pp73-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "93a3209f6bb2b33e725ed08ee0991b92976dfdcf4e8b38646540674fc7508e13",
-              "url": "https://files.pythonhosted.org/packages/bf/75/a04c67c659888d03f164f58851a3522c16d3c09ce3de5734e6e34b48ec6d/cryptography-42.0.7-cp37-abi3-musllinux_1_1_x86_64.whl"
+              "hash": "5226d5d21ab681f432a9c1cf8b658c0cb02533eece706b155e5fbd8a0cdd3949",
+              "url": "https://files.pythonhosted.org/packages/c2/de/8083fa2e68d403553a01a9323f4f8b9d7ffed09928ba25635c29fb28c1e7/cryptography-42.0.8-cp37-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a47787a5e3649008a1102d3df55424e86606c9bae6fb77ac59afe06d234605f8",
-              "url": "https://files.pythonhosted.org/packages/c9/26/4668c980f63a04c697bac26559c1a2a3a2d0730dc3d0f88b87ed7abf76ca/cryptography-42.0.7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "81884c4d096c272f00aeb1f11cf62ccd39763581645b0812e99a91505fa48e0c",
+              "url": "https://files.pythonhosted.org/packages/d5/f3/61b398b5ec61f4b6ffbf746227df7ebb421696458d9625d634043f236a13/cryptography-42.0.8-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a3a5ac8b56fe37f3125e5b72b61dcde43283e5370827f5233893d461b7360cd4",
-              "url": "https://files.pythonhosted.org/packages/cf/c2/8226676b3a4916a12d6c243b1934894e333ea2e97d0233f3260955ed2673/cryptography-42.0.7-cp39-abi3-macosx_10_12_universal2.whl"
+              "hash": "81d8a521705787afe7a18d5bfb47ea9d9cc068206270aad0b96a725022e18d2e",
+              "url": "https://files.pythonhosted.org/packages/f9/8b/1b929ba8139430e09e140e6939c2b29c18df1f2fc2149e41bdbdcdaf5d1f/cryptography-42.0.8-cp37-abi3-macosx_10_12_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7f8b25fa616d8b846aef64b15c606bb0828dbc35faf90566eb139aa9cff67af2",
-              "url": "https://files.pythonhosted.org/packages/d4/08/57c7815d3bb5edeb95da7845cfbd9604393eee955fe139710014f107dac5/cryptography-42.0.7-cp37-abi3-musllinux_1_1_aarch64.whl"
+              "hash": "961e61cefdcb06e0c6d7e3a1b22ebe8b996eb2bf50614e89384be54c48c6b63d",
+              "url": "https://files.pythonhosted.org/packages/fa/5d/31d833daa800e4fab33209843095df7adb4a78ea536929145534cbc15026/cryptography-42.0.8-cp37-abi3-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3577d029bc3f4827dd5bf8bf7710cac13527b470bbf1820a3f394adb38ed7d5f",
-              "url": "https://files.pythonhosted.org/packages/f2/0d/5476959d71a4c427cf02f278a8984cb4197e6a41417961defd8f0aba88f5/cryptography-42.0.7-cp39-abi3-musllinux_1_1_x86_64.whl"
+              "hash": "9c0c1716c8447ee7dbf08d6db2e5c41c688544c61074b54fc4564196f55c25a7",
+              "url": "https://files.pythonhosted.org/packages/fa/e2/b7e6e8c261536c489d9cf908769880d94bd5d9a187e166b0dc838d2e6a56/cryptography-42.0.8-cp39-abi3-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a79165431551042cc9d1d90e6145d5d0d3ab0f2d66326c201d9b0e7f5bf43604",
-              "url": "https://files.pythonhosted.org/packages/f3/df/f528d1deadd8699f876775c59784ce111bb8b2b0c258c53b16fcf91cad33/cryptography-42.0.7-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "d8e3098721b84392ee45af2dd554c947c32cc52f862b6a3ae982dbb90f577f14",
-              "url": "https://files.pythonhosted.org/packages/fa/c8/6dfec89eb609a1fb7b5cf3df35914611582c58dde3d3045fdaedb2853d7b/cryptography-42.0.7-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "a9bc127cdc4ecf87a5ea22a2556cab6c7eda2923f84e4f3cc588e8470ce4e42e",
-              "url": "https://files.pythonhosted.org/packages/fd/b8/08bdd08847b42a9d6d29604bdf6db0521b9c71f5334f0838e082a68b3684/cryptography-42.0.7-cp39-abi3-musllinux_1_1_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "3de9a45d3b2b7d8088c3fbf1ed4395dfeff79d07842217b38df14ef09ce1d8d7",
-              "url": "https://files.pythonhosted.org/packages/fd/eb/b03078f34bfe9c11339773a49c75cb2232471bc7b56b3c353b6a27aed8e8/cryptography-42.0.7-cp37-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "b297f90c5723d04bcc8265fc2a0f86d4ea2e0f7ab4b6994459548d3a6b992a14",
+              "url": "https://files.pythonhosted.org/packages/fd/2b/be327b580645927bb1a1f32d5a175b897a9b956bc085b095e15c40bac9ed/cryptography-42.0.8-cp39-abi3-musllinux_1_2_x86_64.whl"
             }
           ],
           "project_name": "cryptography",
@@ -749,7 +629,7 @@
             "sphinxcontrib-spelling>=4.0.1; extra == \"docstest\""
           ],
           "requires_python": ">=3.7",
-          "version": "42.0.7"
+          "version": "42.0.8"
         },
         {
           "artifacts": [
@@ -856,13 +736,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "77457465d89b8263bca14759d7c1684df840b6811b2499838cc5b040a8b5b113",
-              "url": "https://files.pythonhosted.org/packages/54/4b/965a542baf157f23912e466b50fa9c49dd66132d9495d201e6c607ea16f2/greenlet-3.0.3-cp39-cp39-musllinux_1_1_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "da70d4d51c8b306bb7a031d5cff6cc25ad253affe89b70352af5f1cb68e74b53",
-              "url": "https://files.pythonhosted.org/packages/0b/8a/f5140c8713f919af0e98e6aaa40cb20edaaf3739d18c4a077581e2422ac4/greenlet-3.0.3-cp39-cp39-macosx_11_0_universal2.whl"
+              "hash": "2516a9957eed41dd8f1ec0c604f1cdc86758b587d964668b5b196a9db5bfcde6",
+              "url": "https://files.pythonhosted.org/packages/a4/fa/31e22345518adcd69d1d6ab5087a12c178aa7f3c51103f6d5d702199d243/greenlet-3.0.3-cp312-cp312-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -921,11 +796,6 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "b37eef18ea55f2ffd8f00ff8fe7c8d3818abd3e25fb73fae2ca3b672e333a7a6",
-              "url": "https://files.pythonhosted.org/packages/74/82/9737e7dee4ccb9e1be2a8f17cf760458be2c36c6ff7bbaef55cbe279e729/greenlet-3.0.3-cp39-cp39-musllinux_1_1_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "1f672519db1796ca0d8753f9e78ec02355e862d0998193038c7073045899f305",
               "url": "https://files.pythonhosted.org/packages/7c/68/b5f4084c0a252d7e9c0d95fc1cfc845d08622037adb74e05be3a49831186/greenlet-3.0.3-cp312-cp312-musllinux_1_1_aarch64.whl"
             },
@@ -936,23 +806,8 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "1551a8195c0d4a68fac7a4325efac0d541b48def35feb49d803674ac32582f61",
-              "url": "https://files.pythonhosted.org/packages/9d/ea/8bc7ed08ba274bdaff08f2cb546d832b8f44af267e03ca6e449840486915/greenlet-3.0.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "70fb482fdf2c707765ab5f0b6655e9cfcf3780d8d87355a063547b41177599be",
               "url": "https://files.pythonhosted.org/packages/a2/2f/461615adc53ba81e99471303b15ac6b2a6daa8d2a0f7f77fd15605e16d5b/greenlet-3.0.3-cp312-cp312-macosx_11_0_universal2.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "b7dcbe92cc99f08c8dd11f930de4d99ef756c3591a5377d1d9cd7dd5e896da71",
-              "url": "https://files.pythonhosted.org/packages/a2/92/f11dbbcf33809421447b24d2eefee0575c59c8569d6d03f7ca4d2b34d56f/greenlet-3.0.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "2516a9957eed41dd8f1ec0c604f1cdc86758b587d964668b5b196a9db5bfcde6",
-              "url": "https://files.pythonhosted.org/packages/a4/fa/31e22345518adcd69d1d6ab5087a12c178aa7f3c51103f6d5d702199d243/greenlet-3.0.3-cp312-cp312-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -963,11 +818,6 @@
               "algorithm": "sha256",
               "hash": "d353cadd6083fdb056bb46ed07e4340b0869c305c8ca54ef9da3421acbdf6881",
               "url": "https://files.pythonhosted.org/packages/a6/d6/408ad9603339db28ce334021b1403dfcfbcb7501a435d49698408d928de7/greenlet-3.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "64d7675ad83578e3fc149b617a444fab8efdafc9385471f868eb5ff83e446b8b",
-              "url": "https://files.pythonhosted.org/packages/af/05/b7e068070a6c143f34dfcd7e9144684271b8067e310f6da68269580db1d8/greenlet-3.0.3-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -988,16 +838,6 @@
               "algorithm": "sha256",
               "hash": "c5e1536de2aad7bf62e27baf79225d0d64360d4168cf2e6becb91baf1ed074f3",
               "url": "https://files.pythonhosted.org/packages/c7/ec/85b647e59e0f137c7792a809156f413e38379cf7f3f2e1353c37f4be4026/greenlet-3.0.3-cp311-cp311-musllinux_1_1_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "086152f8fbc5955df88382e8a75984e2bb1c892ad2e3c80a2508954e52295257",
-              "url": "https://files.pythonhosted.org/packages/cf/5b/2de4a398840d3b4d99c4a3476cda0d82badfa349f3f89846ada2e32e9500/greenlet-3.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "d73a9fe764d77f87f8ec26a0c85144d6a951a6c438dfe50487df5595c6373eac",
-              "url": "https://files.pythonhosted.org/packages/dc/c3/06ca5f34b01af6d6e2fd2f97c0ad3673123a442bf4a3add548d374b1cc7c/greenlet-3.0.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
@@ -1088,8 +928,28 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "23a4d95ce9d44161c7aa87ab76ad6056bc1093c461c60c097054a46dc957991f",
-              "url": "https://files.pythonhosted.org/packages/19/25/363376b672f19440c92f0f68b8a6ebc714c6e1c81de29cd973a008fd6882/Levenshtein-0.25.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96",
+              "url": "https://files.pythonhosted.org/packages/b6/85/7882d311924cbcfc70b1890780763e36ff0b140c7e51c110fc59a532f087/isodate-0.6.1-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9",
+              "url": "https://files.pythonhosted.org/packages/db/7a/c0a56c7d56c7fa723988f122fa1f1ccf8c5c4ccc48efad0d214b49e5b1af/isodate-0.6.1.tar.gz"
+            }
+          ],
+          "project_name": "isodate",
+          "requires_dists": [
+            "six"
+          ],
+          "requires_python": null,
+          "version": "0.6.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "dd66fb51f88a3f73a802e1ff19a14978ddc9fbcb7ce3a667ca34f95ef54e0e44",
+              "url": "https://files.pythonhosted.org/packages/95/74/c9101c6844b65b0829fc481e30c4faf05b75d74a567f9bbd23dd2223be6b/Levenshtein-0.25.1-cp312-cp312-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -1128,11 +988,6 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "cbb4e8c4b8b7bbe0e1aa64710b806b6c3f31d93cb14969ae2c0eff0f3a592db8",
-              "url": "https://files.pythonhosted.org/packages/20/13/253f4b99a3aa3359fc162bbc9297308e28a1cd025dc4a803676527ee84e7/Levenshtein-0.25.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "9da9ecb81bae67d784defed7274f894011259b038ec31f2339c4958157970115",
               "url": "https://files.pythonhosted.org/packages/22/76/1333f2c343a952bbedc87d8efb0a5506fe309de81ce3b4dcd2d4582fa6c6/Levenshtein-0.25.1-cp310-cp310-musllinux_1_1_s390x.whl"
             },
@@ -1158,18 +1013,8 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "a164df16d876aab0a400f72aeac870ea97947ea44777c89330e9a16c7dc5cc0e",
-              "url": "https://files.pythonhosted.org/packages/39/d0/babf2b13d9f6197a8d9641a0ca7f987b22e3bdbba210fdf0e2b223462301/Levenshtein-0.25.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "41512c436b8c691326e2d07786d906cba0e92b5e3f455bf338befb302a0ca76d",
               "url": "https://files.pythonhosted.org/packages/3b/d9/b31254b20bc5c600c48039840ea56793e191677dd8e2ed59fea2b0c6658a/Levenshtein-0.25.1-cp311-cp311-musllinux_1_1_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "f8dc3e63c4cd746ec162a4cd744c6dde857e84aaf8c397daa46359c3d54e6219",
-              "url": "https://files.pythonhosted.org/packages/3d/87/0c86a9b83675d98bf2b84f60b1cef6d28224e8ffa5128012b0c312e403cf/Levenshtein-0.25.1-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -1180,11 +1025,6 @@
               "algorithm": "sha256",
               "hash": "f2a69fe5ddea586d439f9a50d0c51952982f6c0db0e3573b167aa17e6d1dfc48",
               "url": "https://files.pythonhosted.org/packages/46/07/a97aa53a5ed0aa3200baf7a47c5c0fce961b443338f051bc64b9a459982e/Levenshtein-0.25.1-cp311-cp311-musllinux_1_1_i686.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "e8dd4c201b15f8c1e612f9074335392c8208ac147acbce09aff04e3974bf9b16",
-              "url": "https://files.pythonhosted.org/packages/4b/6e/404bc5b0c9b8a924a213e4aee65ed5f77a8dbfbc692430199330e69a918d/Levenshtein-0.25.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -1218,18 +1058,8 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "fddc0ccbdd94f57aa32e2eb3ac8310d08df2e175943dc20b3e1fc7a115850af4",
-              "url": "https://files.pythonhosted.org/packages/5b/e5/25b05df64d1e3ae74abc6c2ae2259f57326b546ec1692090c6e15c237971/Levenshtein-0.25.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "f57d9cf06dac55c2d2f01f0d06e32acc074ab9a902921dc8fddccfb385053ad5",
               "url": "https://files.pythonhosted.org/packages/5d/3f/714710da7c556d59fde54aae860eec7adbc03ace91d4317ca70799b51d0c/Levenshtein-0.25.1-cp311-cp311-macosx_10_9_universal2.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "78fba73c352383b356a30c4674e39f086ffef7122fa625e7550b98be2392d387",
-              "url": "https://files.pythonhosted.org/packages/62/4f/50b34f77cee7e64818cce8c9b79656d3282bc556bfba78cb8843272c79fd/Levenshtein-0.25.1-cp39-cp39-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
@@ -1273,33 +1103,8 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "bdaf62d637bef6711d6f3457e2684faab53b2db2ed53c05bc0dc856464c74742",
-              "url": "https://files.pythonhosted.org/packages/8d/2a/3f69887eacc5976f7f821785e98790d7b87cb210139022b572dcfb9a2684/Levenshtein-0.25.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "b48d1fe224b365975002e3e2ea947cbb91d2936a16297859b71c4abe8a39932c",
-              "url": "https://files.pythonhosted.org/packages/90/76/5413e6adcf9563308f9947d229eb12f31b3eb63b61adce9489be7b4c37dd/Levenshtein-0.25.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "dd66fb51f88a3f73a802e1ff19a14978ddc9fbcb7ce3a667ca34f95ef54e0e44",
-              "url": "https://files.pythonhosted.org/packages/95/74/c9101c6844b65b0829fc481e30c4faf05b75d74a567f9bbd23dd2223be6b/Levenshtein-0.25.1-cp312-cp312-musllinux_1_1_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "b8db9f672a5d150706648b37b044dba61f36ab7216c6a121cebbb2899d7dfaa3",
               "url": "https://files.pythonhosted.org/packages/97/bd/587a5beab993d46952da56418619922be6f33b5be6540922bbdfb6b3866a/Levenshtein-0.25.1-cp311-cp311-musllinux_1_1_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "5dcf931b64311039b43495715e9b795fbd97ab44ba3dd6bf24360b15e4e87649",
-              "url": "https://files.pythonhosted.org/packages/98/27/5195d4bebb65384970c3c5016a8c8502982f942b22711dee4a006dd27f75/Levenshtein-0.25.1-cp39-cp39-musllinux_1_1_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "995d3bcedcf64be6ceca423f6cfe29184a36d7c4cbac199fdc9a0a5ec7196cf5",
-              "url": "https://files.pythonhosted.org/packages/b2/b7/3a16eb7bd269a2010dca5f4c9386b94e007b4b57acb8f6097b2fdd784da4/Levenshtein-0.25.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -1315,16 +1120,6 @@
               "algorithm": "sha256",
               "hash": "147221cfb1d03ed81d22fdd2a4c7fc2112062941b689e027a30d2b75bbced4a3",
               "url": "https://files.pythonhosted.org/packages/c3/05/817f8b28a170b8962f381ed5cea64ee16748b4ceae076a6652551a7bb1c4/Levenshtein-0.25.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "387f768bb201b9bc45f0f49557e2fb9a3774d9d087457bab972162dcd4fd352b",
-              "url": "https://files.pythonhosted.org/packages/c4/78/be1f3abc0289f9cc3df3f411286a889b3e0f87642d08f3d8546de476e49c/Levenshtein-0.25.1-cp39-cp39-musllinux_1_1_s390x.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "af9de3b5f8f5f3530cfd97daab9ab480d1b121ef34d8c0aa5bab0c645eae219e",
-              "url": "https://files.pythonhosted.org/packages/c6/a7/1140afa92d248961707adb0fcaf5fc7f5499d66ed26d0ccdf1041d304f86/Levenshtein-0.25.1-cp39-cp39-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
@@ -1348,26 +1143,6 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "45682cdb3ac4a5465c01b2dce483bdaa1d5dcd1a1359fab37d26165b027d3de2",
-              "url": "https://files.pythonhosted.org/packages/f1/69/9154e83cdb2b008f564d90c10b580fed54725456dbae4896334d35bed3b9/Levenshtein-0.25.1-cp39-cp39-macosx_10_9_universal2.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "01ad1eb09933a499a49923e74e05b1428ca4ef37fed32965fef23f1334a11563",
-              "url": "https://files.pythonhosted.org/packages/f2/a4/0bbeb5753517b02f3990c3bfd9846916bec38c52e775f2d8397f256c4747/Levenshtein-0.25.1-cp39-cp39-macosx_11_0_arm64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "7d52249cb3448bfe661d3d7db3a6673e835c7f37b30b0aeac499a1601bae873d",
-              "url": "https://files.pythonhosted.org/packages/f9/0c/743786f3ceaaffd28fd9204b4bf8413293390ac2e6b246186b5fa19338c0/Levenshtein-0.25.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "9e0df0dcea3943321398f72e330c089b5d5447318310db6f17f5421642f3ade6",
-              "url": "https://files.pythonhosted.org/packages/fb/51/8b3d0a5293f70c5c83e37e14021b65bcaa116a3a4aebb7d0a1381ca769c9/Levenshtein-0.25.1-cp39-cp39-musllinux_1_1_ppc64le.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "22b60c6d791f4ca67a3686b557ddb2a48de203dae5214f220f9dddaab17f44bb",
               "url": "https://files.pythonhosted.org/packages/fc/26/38a817f56c7519791acd73d3f4fe7f753da294d7221f9f8a867d69964dd4/Levenshtein-0.25.1-cp311-cp311-macosx_10_9_x86_64.whl"
             }
@@ -1383,19 +1158,366 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
-              "url": "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl"
+              "hash": "b128092c927eaf485928cec0c28f6b8bead277e28acf56800e972aa2c2abd7a2",
+              "url": "https://files.pythonhosted.org/packages/59/03/df1fc5b9f1db8502863ebef8f6a6f37131d7e7c432e997724689221052d9/lxml-5.2.2-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9",
-              "url": "https://files.pythonhosted.org/packages/ee/b5/b43a27ac7472e1818c4bafd44430e69605baefe1f34440593e0332ec8b4d/packaging-24.0.tar.gz"
+              "hash": "b537bd04d7ccd7c6350cdaaaad911f6312cbd61e6e6045542f781c7f8b2e99d2",
+              "url": "https://files.pythonhosted.org/packages/00/68/cd5637510441ab4556f087b342000e4ae2d0cf3bea67b073a4327f31020c/lxml-5.2.2-pp310-pypy310_pp73-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "dfa7c241073d8f2b8e8dbc7803c434f57dbb83ae2a3d7892dd068d99e96efe2c",
+              "url": "https://files.pythonhosted.org/packages/03/f4/73ea84c176aaff04ca10093fc7ac3912c4aa4793ef1c3f5a963a40db0a6f/lxml-5.2.2-cp310-cp310-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "74e4f025ef3db1c6da4460dd27c118d8cd136d0391da4e387a15e48e5c975147",
+              "url": "https://files.pythonhosted.org/packages/06/0f/fd5d42f906eff843c9080fba7fdd005cdf1be697e19517013938c0581eed/lxml-5.2.2-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "981a06a3076997adf7c743dcd0d7a0415582661e2517c7d961493572e909aa1d",
+              "url": "https://files.pythonhosted.org/packages/06/53/6994084d29251e9ee0e8486d82416836a9d009208853e8216cbc4c924c8c/lxml-5.2.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6dfdc2bfe69e9adf0df4915949c22a25b39d175d599bf98e7ddf620a13678585",
+              "url": "https://files.pythonhosted.org/packages/08/e1/51f6ad2bdb5f28fceeb6bd591d4a0ed5de42ffc6741fd88eb2209c6a46f2/lxml-5.2.2-cp312-cp312-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ae4073a60ab98529ab8a72ebf429f2a8cc612619a8c04e08bed27450d52103c0",
+              "url": "https://files.pythonhosted.org/packages/0a/99/a3abdfcde8f2a171a9e5f63b97bf2a6a6612c2356af151fb2bdc949e77ba/lxml-5.2.2-cp310-cp310-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "657a972f46bbefdbba2d4f14413c0d079f9ae243bd68193cb5061b9732fa54c1",
+              "url": "https://files.pythonhosted.org/packages/15/3d/d84d07fc450af34ce49b88a5aac805b486f38c9f9305fba647a39367c51c/lxml-5.2.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ffb2be176fed4457e445fe540617f0252a72a8bc56208fd65a690fdb1f57660b",
+              "url": "https://files.pythonhosted.org/packages/1e/3c/ba4aa85a49a7bb9fef7062cd7f584b3da59d4bba82cef375164b95f60834/lxml-5.2.2-cp310-cp310-musllinux_1_2_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3b6a30a9ab040b3f545b697cb3adbf3696c05a3a68aad172e3fd7ca73ab3c835",
+              "url": "https://files.pythonhosted.org/packages/1f/fb/510777421d0231b3f601d7d6a9a494717bac3a206eca1518b38a869f5289/lxml-5.2.2-cp310-cp310-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "08ea0f606808354eb8f2dfaac095963cb25d9d28e27edcc375d7b30ab01abbf6",
+              "url": "https://files.pythonhosted.org/packages/25/6c/02cecb6a26b0baec373baa3f4fb55343cf0d8710d6a853ff4c4b12a9cf16/lxml-5.2.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7429e7faa1a60cad26ae4227f4dd0459efde239e494c7312624ce228e04f6391",
+              "url": "https://files.pythonhosted.org/packages/26/36/6e00905cb4de2d014f4a62df58f0e82d262b5461245d951a6e7442b0222a/lxml-5.2.2-cp312-cp312-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a233bb68625a85126ac9f1fc66d24337d6e8a0f9207b688eec2e7c880f012ec0",
+              "url": "https://files.pythonhosted.org/packages/27/0a/82b3f5b375d3252a76e73efb56857424804f5dabce62712e256f96d0fa69/lxml-5.2.2-cp310-cp310-musllinux_1_1_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0969e92af09c5687d769731e3f39ed62427cc72176cebb54b7a9d52cc4fa3b73",
+              "url": "https://files.pythonhosted.org/packages/27/7f/9e203e850609fa12c8b347fcceaba8655f062bc19ace7a837bb7fcf64b8f/lxml-5.2.2-cp312-cp312-manylinux_2_28_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d237ba6664b8e60fd90b8549a149a74fcc675272e0e95539a00522e4ca688b04",
+              "url": "https://files.pythonhosted.org/packages/2f/ca/0376418e202e9423d47f86ae09db885fa6e109d0efb602f6468e6d1e8e77/lxml-5.2.2-cp311-cp311-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "96e85aa09274955bb6bd483eaf5b12abadade01010478154b0ec70284c1b1526",
+              "url": "https://files.pythonhosted.org/packages/31/47/64914d8e752c9dd13b7da69ca7b9f645983412206936058b5261c2c9e093/lxml-5.2.2-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1a7aca7964ac4bb07680d5c9d63b9d7028cace3e2d43175cb50bba8c5ad33316",
+              "url": "https://files.pythonhosted.org/packages/38/bc/e9269ba955b66ef2af8559d405514d8c055b5dfa58cec71f78f0bc4d7493/lxml-5.2.2-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "23441e2b5339bc54dc949e9e675fa35efe858108404ef9aa92f0456929ef6fe8",
+              "url": "https://files.pythonhosted.org/packages/3b/ca/5d74a0572c911f8dbf12d89abe0fdcbe0409c18978b5694392becd4d56fb/lxml-5.2.2-cp311-cp311-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f11ae142f3a322d44513de1018b50f474f8f736bc3cd91d969f464b5bfef8836",
+              "url": "https://files.pythonhosted.org/packages/3e/fa/b361d670ffa8f477504b7fc0e5734a7878815c7e0b6769f3a5a903a94aee/lxml-5.2.2-cp312-cp312-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b0b3f2df149efb242cee2ffdeb6674b7f30d23c9a7af26595099afaf46ef4e88",
+              "url": "https://files.pythonhosted.org/packages/4e/42/3bfe92749715c819763d2205370ecc7f586b44e277f38839e27cce7d6bb8/lxml-5.2.2-cp311-cp311-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2eb2227ce1ff998faf0cd7fe85bbf086aa41dfc5af3b1d80867ecfe75fb68df3",
+              "url": "https://files.pythonhosted.org/packages/4e/56/c35969591789763657eb16c2fa79c924823b97da5536da8b89e11582da89/lxml-5.2.2-cp311-cp311-manylinux_2_28_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b47633251727c8fe279f34025844b3b3a3e40cd1b198356d003aa146258d13a2",
+              "url": "https://files.pythonhosted.org/packages/54/4d/47eb532c0472bb5495efe899740e3d928ddb79599e73d156d4cfa8e126a3/lxml-5.2.2-cp310-cp310-manylinux_2_28_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e282aedd63c639c07c3857097fc0e236f984ceb4089a8b284da1c526491e3f3d",
+              "url": "https://files.pythonhosted.org/packages/5b/70/1c45927de1cd7dc47292cfa8a9eb7928b38ce5647d66601bd169b25af4a7/lxml-5.2.2-cp312-cp312-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e290d79a4107d7d794634ce3e985b9ae4f920380a813717adf61804904dc4393",
+              "url": "https://files.pythonhosted.org/packages/5c/5d/faebbdaae16a40eb559b3e1bf0548e23ad43716f1c5e781c1d2f9ac900ec/lxml-5.2.2-cp310-cp310-musllinux_1_2_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1a2569a1f15ae6c8c64108a2cd2b4a858fc1e13d25846be0666fc144715e32ab",
+              "url": "https://files.pythonhosted.org/packages/5f/e0/4cd021850f2e8ab5ce6ce294556300bd4b5c1eb7def88b5f859449dc883c/lxml-5.2.2-cp311-cp311-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bb2dc4898180bea79863d5487e5f9c7c34297414bad54bcd0f0852aee9cfdb87",
+              "url": "https://files.pythonhosted.org/packages/63/f7/ffbb6d2eb67b80a45b8a0834baa5557a14a5ffce0979439e7cd7f0c4055b/lxml-5.2.2.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "07542787f86112d46d07d4f3c4e7c760282011b354d012dc4141cc12a68cef5f",
+              "url": "https://files.pythonhosted.org/packages/67/c7/6060ea3efbd1a60a10963b1b09f493fc8f6f6728310a7a77479a3f9ab20a/lxml-5.2.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "aef5474d913d3b05e613906ba4090433c515e13ea49c837aca18bde190853dff",
+              "url": "https://files.pythonhosted.org/packages/68/ad/3cbe5b7005722cae504f3cc2879f444f6407fb1a8a1f53050f03ca784c46/lxml-5.2.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1e275ea572389e41e8b039ac076a46cb87ee6b8542df3fff26f5baab43713bca",
+              "url": "https://files.pythonhosted.org/packages/6b/2d/ea82f53acc12e7245a1927de78093654d140e6ef12bd2fcae41436c936da/lxml-5.2.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "33ce9e786753743159799fdf8e92a5da351158c4bfb6f2db0bf31e7892a1feb5",
+              "url": "https://files.pythonhosted.org/packages/6b/cc/8e73a63c2aeb205fbed44272fea8c5ded07920233b9956e8e304e2516931/lxml-5.2.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ab67ed772c584b7ef2379797bf14b82df9aa5f7438c5b9a09624dd834c1c1aaf",
+              "url": "https://files.pythonhosted.org/packages/73/3f/5a22be26edce482cb5dbdc5cf75544cfd1d3fb1389124d06995395829617/lxml-5.2.2-cp312-cp312-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0b3f5016e00ae7630a4b83d0868fca1e3d494c78a75b1c7252606a3a1c5fc2ad",
+              "url": "https://files.pythonhosted.org/packages/74/c4/4e6f5e2be18f8eb76dff5bff3619c2c654650fee93aea37a92866efe90bc/lxml-5.2.2-cp311-cp311-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "fbc9d316552f9ef7bba39f4edfad4a734d3d6f93341232a9dddadec4f15d425f",
+              "url": "https://files.pythonhosted.org/packages/78/73/82a00717a29330cf56a4a7f3077aa7ee4d5171e79fcdd7d161d90df53122/lxml-5.2.2-cp310-cp310-manylinux_2_28_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4aefd911793b5d2d7a921233a54c90329bf3d4a6817dc465f12ffdfe4fc7b8fe",
+              "url": "https://files.pythonhosted.org/packages/81/13/7df8804d4fb678e0216f6f4532754fd471856b5cb24726dab55a3b65f527/lxml-5.2.2-cp312-cp312-musllinux_1_2_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2fb0ba3e8566548d6c8e7dd82a8229ff47bd8fb8c2da237607ac8e5a1b8312e5",
+              "url": "https://files.pythonhosted.org/packages/83/07/d95e9663ad8d875f344930e4fb52a0a6f56225267d3cc6e3e9bfa44ca736/lxml-5.2.2-cp311-cp311-musllinux_1_2_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bcc98f911f10278d1daf14b87d65325851a1d29153caaf146877ec37031d5f36",
+              "url": "https://files.pythonhosted.org/packages/84/2e/dac726231781599429ea0b3faf018c081334a68c68708e7381077f447033/lxml-5.2.2-cp310-cp310-manylinux_2_28_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "303f540ad2dddd35b92415b74b900c749ec2010e703ab3bfd6660979d01fd4ed",
+              "url": "https://files.pythonhosted.org/packages/8a/f7/f5df71c70c4d14d186dd86fd0e9ebeffdb63b9b86fb19fe9315f9576266b/lxml-5.2.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f2a09f6184f17a80897172863a655467da2b11151ec98ba8d7af89f17bf63dae",
+              "url": "https://files.pythonhosted.org/packages/95/d1/ff0c68a61a385f6dffd4c099bc9720cb127bb94f0df8e71f52fe539f85b7/lxml-5.2.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f5b65529bb2f21ac7861a0e94fdbf5dc0daab41497d18223b46ee8515e5ad297",
+              "url": "https://files.pythonhosted.org/packages/98/59/3877fd55ebc6d0f426583137bedeee21c9f6d5d5c829664a14103f5279a7/lxml-5.2.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "56793b7a1a091a7c286b5f4aa1fe4ae5d1446fe742d00cdf2ffb1077865db10d",
+              "url": "https://files.pythonhosted.org/packages/99/a1/d91217a8d7fef5ac41af87c916d322c273a9b2047c735ea1dafa2ac46d16/lxml-5.2.2-cp311-cp311-manylinux_2_28_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d26a618ae1766279f2660aca0081b2220aca6bd1aa06b2cf73f07383faf48927",
+              "url": "https://files.pythonhosted.org/packages/9a/87/cff3c63ebe067ec9a7cc1948c379b8a16e7990c29bd5baf77c0a1dbd03c0/lxml-5.2.2-cp312-cp312-manylinux_2_28_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "364d03207f3e603922d0d3932ef363d55bbf48e3647395765f9bfcbdf6d23632",
+              "url": "https://files.pythonhosted.org/packages/9b/e9/73c7e6f9a933ee82cd68599d6291c875379cbce2c47717b811744cfd2256/lxml-5.2.2-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8268cbcd48c5375f46e000adb1390572c98879eb4f77910c6053d25cc3ac2c67",
+              "url": "https://files.pythonhosted.org/packages/9d/3e/b7464d5c06a57cb206fd14a9251bfa75ae03d4f6b1c0c41cf82111bdfa3b/lxml-5.2.2-cp312-cp312-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "76acba4c66c47d27c8365e7c10b3d8016a7da83d3191d053a58382311a8bf4e1",
+              "url": "https://files.pythonhosted.org/packages/a8/3c/c9ce5ba91764aaea8944b8e90543ba2e8fc2610d4c5c052160e83ac100b6/lxml-5.2.2-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "eb00b549b13bd6d884c863554566095bf6fa9c3cecb2e7b399c4bc7904cb33b5",
+              "url": "https://files.pythonhosted.org/packages/ad/b7/0dc82afed00c4c189cfd0b83464f9a431c66de8e73d911063956a147276a/lxml-5.2.2-cp311-cp311-manylinux_2_28_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ec87c44f619380878bd49ca109669c9f221d9ae6883a5bcb3616785fa8f94c97",
+              "url": "https://files.pythonhosted.org/packages/ae/fc/6020fe1468fccb684619df6765a79b67229091631e5f14b97c3efcd75ca7/lxml-5.2.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "dc911208b18842a3a57266d8e51fc3cfaccee90a5351b92079beed912a7914c2",
+              "url": "https://files.pythonhosted.org/packages/b4/1f/6a88a8e1b6a9be644c74e5f72cf581cb342a392e020c60a389cd194ebba1/lxml-5.2.2-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3d1e35572a56941b32c239774d7e9ad724074d37f90c7a7d499ab98761bd80cf",
+              "url": "https://files.pythonhosted.org/packages/b5/66/007666e7878ca746e44da3b4c2acf9d5c617dd51e152e89589e7eeb59f87/lxml-5.2.2-cp312-cp312-musllinux_1_1_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b74b9ea10063efb77a965a8d5f4182806fbf59ed068b3c3fd6f30d2ac7bee734",
+              "url": "https://files.pythonhosted.org/packages/bc/c6/32af0ec3e8323e12212c064f924ddf993017e68d1f50e03da2a3be1289c1/lxml-5.2.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "13e69be35391ce72712184f69000cda04fc89689429179bc4c0ae5f0b7a8c21b",
+              "url": "https://files.pythonhosted.org/packages/c6/24/8ddb86ab14428d4d222a383a5260eea93728192359a1fff5de8f7fa13374/lxml-5.2.2-cp310-cp310-manylinux_2_28_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "74da9f97daec6928567b48c90ea2c82a106b2d500f397eeb8941e47d30b1ca85",
+              "url": "https://files.pythonhosted.org/packages/cd/e7/63435cfa76534fb33a9656507057b96a25bb850ae932424b9724c9fe379e/lxml-5.2.2-cp312-cp312-manylinux_2_28_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d28cb356f119a437cc58a13f8135ab8a4c8ece18159eb9194b0d269ec4e28083",
+              "url": "https://files.pythonhosted.org/packages/d5/fd/4899215277e3ef1767019fab178fad8a149081f80cf886a73dc0ba1badae/lxml-5.2.2-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "50ccb5d355961c0f12f6cf24b7187dbabd5433f29e15147a67995474f27d1776",
+              "url": "https://files.pythonhosted.org/packages/d6/68/7e9de19d47cd5430414063cd7739e8c8d8386016740c18af5ff13b64ff5c/lxml-5.2.2-cp312-cp312-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8b8df03a9e995b6211dafa63b32f9d405881518ff1ddd775db4e7b98fb545e1c",
+              "url": "https://files.pythonhosted.org/packages/d7/7d/c98b7ef3e496a9c371057dc955be1fda04dab4e8af488b01bec254e1b59b/lxml-5.2.2-cp312-cp312-musllinux_1_2_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9164361769b6ca7769079f4d426a41df6164879f7f3568be9086e15baca61466",
+              "url": "https://files.pythonhosted.org/packages/d9/d2/089fcb90e6bdd16639656c2632573508ae02f42a3b034376d3e32efd2ccc/lxml-5.2.2-cp312-cp312-manylinux_2_28_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "45f9494613160d0405682f9eee781c7e6d1bf45f819654eb249f8f46a2c22545",
+              "url": "https://files.pythonhosted.org/packages/da/6a/24e9f77d17668dd4ac0a6c2a56113fd3e0db07cee51e3a67afcd47c597e5/lxml-5.2.2-cp311-cp311-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "75a9632f1d4f698b2e6e2e1ada40e71f369b15d69baddb8968dcc8e683839b18",
+              "url": "https://files.pythonhosted.org/packages/de/12/0253de661bb9f8c26b47059be4ed2ec5b9e4411fd2b1d45a2f4b399a7616/lxml-5.2.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "79d1fb9252e7e2cfe4de6e9a6610c7cbb99b9708e2c3e29057f487de5a9eaefa",
+              "url": "https://files.pythonhosted.org/packages/df/e1/9ebae8d05492a8e9f632f2add15199e7bca5c1b063444e360a7bde685718/lxml-5.2.2-cp311-cp311-musllinux_1_2_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1d8a701774dfc42a2f0b8ccdfe7dbc140500d1049e0632a611985d943fcf12df",
+              "url": "https://files.pythonhosted.org/packages/e7/28/1809a5406282c03df561a3c8143c143bd515d5668f1a138f51aec6d2618e/lxml-5.2.2-cp311-cp311-manylinux_2_28_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6dcc3d17eac1df7859ae01202e9bb11ffa8c98949dcbeb1069c8b9a75917e01b",
+              "url": "https://files.pythonhosted.org/packages/ec/ab/189f571450e3393d4d442f88683d11b5a47c88e66a4e6b0d467500360483/lxml-5.2.2-cp311-cp311-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8cf85a6e40ff1f37fe0f25719aadf443686b1ac7652593dc53c7ef9b8492b115",
+              "url": "https://files.pythonhosted.org/packages/f0/f4/fb01451fda1e121eb8f117a00040454ca05a9c9d82b308272042eebd05f3/lxml-5.2.2-cp311-cp311-musllinux_1_1_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "50127c186f191b8917ea2fb8b206fbebe87fd414a6084d15568c27d0a21d60db",
+              "url": "https://files.pythonhosted.org/packages/f2/1e/364a7e4afe9d27cef4f7a684ace409a379c953fe0881b0f2ff67380ed9ea/lxml-5.2.2-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4820c02195d6dfb7b8508ff276752f6b2ff8b64ae5d13ebe02e7667e035000b9",
+              "url": "https://files.pythonhosted.org/packages/f6/e0/1122d5b6a10eb71fac4276a0d3b1f5cf1ef0a29f774601d4740e80a70e1a/lxml-5.2.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            }
+          ],
+          "project_name": "lxml",
+          "requires_dists": [
+            "BeautifulSoup4; extra == \"htmlsoup\"",
+            "Cython>=3.0.10; extra == \"source\"",
+            "cssselect>=0.7; extra == \"cssselect\"",
+            "html5lib; extra == \"html5\"",
+            "lxml-html-clean; extra == \"html-clean\""
+          ],
+          "requires_python": ">=3.6",
+          "version": "5.2.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "ea6a02e24a9161e51faad17a8782b92a0df82c12c1c8886fec7f0c3fa1a1b320",
+              "url": "https://files.pythonhosted.org/packages/bb/23/2d1cdb0427aecb2b150dc2ac2d15400990c4f05585b3fbc1b5177d74d7fb/more_itertools-10.3.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e5d93ef411224fbcef366a6e8ddc4c5781bc6359d43412a65dd5964e46111463",
+              "url": "https://files.pythonhosted.org/packages/01/33/77f586de725fc990d12dda3d4efca4a41635be0f99a987b9cc3a78364c13/more-itertools-10.3.0.tar.gz"
+            }
+          ],
+          "project_name": "more-itertools",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "10.3.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124",
+              "url": "https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002",
+              "url": "https://files.pythonhosted.org/packages/51/65/50db4dda066951078f0a96cf12f4b9ada6e4b811516bf0262c0f4f7064d4/packaging-24.1.tar.gz"
             }
           ],
           "project_name": "packaging",
           "requires_dists": [],
-          "requires_python": ">=3.7",
-          "version": "24.0"
+          "requires_python": ">=3.8",
+          "version": "24.1"
         },
         {
           "artifacts": [
@@ -1428,6 +1550,35 @@
           ],
           "requires_python": ">=3.7",
           "version": "1.3.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee",
+              "url": "https://files.pythonhosted.org/packages/68/13/2aa1f0e1364feb2c9ef45302f387ac0bd81484e9c9a4c5688a322fbdfd08/platformdirs-4.2.2-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3",
+              "url": "https://files.pythonhosted.org/packages/f5/52/0763d1d976d5c262df53ddda8d8d4719eedf9594d046f117c25a27261a19/platformdirs-4.2.2.tar.gz"
+            }
+          ],
+          "project_name": "platformdirs",
+          "requires_dists": [
+            "appdirs==1.4.4; extra == \"test\"",
+            "covdefaults>=2.3; extra == \"test\"",
+            "furo>=2023.9.10; extra == \"docs\"",
+            "mypy>=1.8; extra == \"type\"",
+            "proselint>=0.13; extra == \"docs\"",
+            "pytest-cov>=4.1; extra == \"test\"",
+            "pytest-mock>=3.12; extra == \"test\"",
+            "pytest>=7.4.3; extra == \"test\"",
+            "sphinx-autodoc-typehints>=1.25.2; extra == \"docs\"",
+            "sphinx>=7.2.6; extra == \"docs\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "4.2.2"
         },
         {
           "artifacts": [
@@ -1497,301 +1648,216 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e029badca45266732a9a79898a15ae2e8b14840b1eabbb25844be28f0b33f3d5",
-              "url": "https://files.pythonhosted.org/packages/ed/76/9a17032880ed27f2dbd490c77a3431cbc80f47ba81534131de3c2846e736/pydantic-2.7.1-py3-none-any.whl"
+              "hash": "ee8538d41ccb9c0a9ad3e0e5f07bf15ed8015b481ced539a1759d8cc89ae90d0",
+              "url": "https://files.pythonhosted.org/packages/17/ba/1b65c9cbc49e0c7cd1be086c63209e9ad883c2a409be4746c21db4263f41/pydantic-2.7.4-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e9dbb5eada8abe4d9ae5f46b9939aead650cd2b68f249bb3a8139dbe125803cc",
-              "url": "https://files.pythonhosted.org/packages/1f/74/0d009e056c2bd309cdc053b932d819fcb5ad3301fc3e690c097e1de3e714/pydantic-2.7.1.tar.gz"
+              "hash": "0c84efd9548d545f63ac0060c1e4d39bb9b14db8b3c0652338aecc07b5adec52",
+              "url": "https://files.pythonhosted.org/packages/0d/fc/ccd0e8910bc780f1a4e1ab15e97accbb1f214932e796cff3131f9a943967/pydantic-2.7.4.tar.gz"
             }
           ],
           "project_name": "pydantic",
           "requires_dists": [
             "annotated-types>=0.4.0",
             "email-validator>=2.0.0; extra == \"email\"",
-            "pydantic-core==2.18.2",
+            "pydantic-core==2.18.4",
             "typing-extensions>=4.6.1"
           ],
           "requires_python": ">=3.8",
-          "version": "2.7.1"
+          "version": "2.7.4"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b3ef08e20ec49e02d5c6717a91bb5af9b20f1805583cb0adfe9ba2c6b505b5ae",
-              "url": "https://files.pythonhosted.org/packages/88/6c/e37969d13d7aeca27c8b0d54ae5cea84549b5058657392a959629d8e1f45/pydantic_core-2.18.2-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl"
+              "hash": "81b5efb2f126454586d0f40c4d834010979cb80785173d1586df845a632e4e6d",
+              "url": "https://files.pythonhosted.org/packages/b0/8a/c8a2e60482eebc5c878faf7067e63ef532d40b01870292a7da40506b2d5f/pydantic_core-2.18.4-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "eff2de745698eb46eeb51193a9f41d67d834d50e424aef27df2fcdee1b153845",
-              "url": "https://files.pythonhosted.org/packages/07/fc/8d39be070e845640504dcfec198f633c78e6dfd3fc9cecea87400c75dec4/pydantic_core-2.18.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "ec3beeada09ff865c344ff3bc2f427f5e6c26401cc6113d77e372c3fdac73864",
+              "url": "https://files.pythonhosted.org/packages/02/d0/622cdfe12fb138d035636f854eb9dc414f7e19340be395799de87c1de6f6/pydantic_core-2.18.4.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "224c421235f6102e8737032483f43c1a8cfb1d2f45740c44166219599358c2cd",
-              "url": "https://files.pythonhosted.org/packages/0c/10/fc86b5cf407a0a2c0b01796f920b5568e13009d2c3a2c999188b1908718f/pydantic_core-2.18.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              "hash": "a55b5b16c839df1070bc113c1f7f94a0af4433fcfa1b41799ce7606e5c79ce0a",
+              "url": "https://files.pythonhosted.org/packages/07/a1/a0156c29cf3ee6b7db7907baa2666be42603fe87f518eb6b98fd982906ba/pydantic_core-2.18.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cfeecd1ac6cc1fb2692c3d5110781c965aabd4ec5d32799773ca7b1456ac636b",
-              "url": "https://files.pythonhosted.org/packages/0e/2a/1154d61fcbae730e8eec69df18b7cd8ec41d06bf2983257f05ae5923bf58/pydantic_core-2.18.2-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "5f09baa656c904807e832cf9cce799c6460c450c4ad80803517032da0cd062e2",
+              "url": "https://files.pythonhosted.org/packages/17/24/517cb7e5839754b0855c50c92cdd8715919d05a360b94dc5cf181d5fe60d/pydantic_core-2.18.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ca7b0c1f1c983e064caa85f3792dd2fe3526b3505378874afa84baf662e12241",
-              "url": "https://files.pythonhosted.org/packages/0e/b9/28dc15be5a828708612cc429354609b456719f70180af9c66d7617bbac60/pydantic_core-2.18.2-cp312-cp312-musllinux_1_1_aarch64.whl"
+              "hash": "942ba11e7dfb66dc70f9ae66b33452f51ac7bb90676da39a7345e99ffb55402d",
+              "url": "https://files.pythonhosted.org/packages/25/ba/f8106ec853ed1e288490c39796322cb54f96685e53a1b302c6d7d5d3528e/pydantic_core-2.18.4-cp311-cp311-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f459a5ce8434614dfd39bbebf1041952ae01da6bed9855008cb33b875cb024c0",
-              "url": "https://files.pythonhosted.org/packages/10/95/7b7d9b73e490349470f3635e3728eba7df3c809bc75efd9a8aed2f00f207/pydantic_core-2.18.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "1f4d26ceb5eb9eed4af91bebeae4b06c3fb28966ca3a8fb765208cf6b51102ab",
+              "url": "https://files.pythonhosted.org/packages/35/22/cf65f4a902c3b5ff6fcbd159fa626f95d56aaff8c318952e23af179e7e25/pydantic_core-2.18.4-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e6dac87ddb34aaec85f873d737e9d06a3555a1cc1a8e0c44b7f8d5daeb89d86f",
-              "url": "https://files.pythonhosted.org/packages/11/4e/e06605ce50035dd9bf107dda3d514e4b1ba82a5551ef57a15e73e47d9053/pydantic_core-2.18.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "f76d0ad001edd426b92233d45c746fd08f467d56100fd8f30e9ace4b005266e4",
+              "url": "https://files.pythonhosted.org/packages/4d/73/af096181c7aeaf087c23f6cb45a545a1bb5b48b6da2b6b2c0c2d7b34f166/pydantic_core-2.18.4-cp310-cp310-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fb2bd7be70c0fe4dfd32c951bc813d9fe6ebcbfdd15a07527796c8204bd36242",
-              "url": "https://files.pythonhosted.org/packages/15/b1/e6edfe46402a5b415fc3de86aa64fb10009b323907f8d513175bfb839aa9/pydantic_core-2.18.2-cp312-cp312-macosx_10_12_x86_64.whl"
+              "hash": "a642295cd0c8df1b86fc3dced1d067874c353a188dc8e0f744626d49e9aa51c4",
+              "url": "https://files.pythonhosted.org/packages/4d/cd/f29239ba9e23a4cbe27ebac22652f9c93b3f2122bd8b96bd51f72bbf7009/pydantic_core-2.18.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4456f2dca97c425231d7315737d45239b2b51a50dc2b6f0c2bb181fce6207664",
-              "url": "https://files.pythonhosted.org/packages/1f/89/dbe3dd03e0d5c68f50f6aa98607221a304168196ee84e835747705cb7005/pydantic_core-2.18.2-cp311-cp311-musllinux_1_1_x86_64.whl"
+              "hash": "4701b19f7e3a06ea655513f7938de6f108123bf7c86bbebb1196eb9bd35cf724",
+              "url": "https://files.pythonhosted.org/packages/5f/ac/2a0a53a5df1243b670b3250a78673eb135f13a0a23e55d8e1fd68c54e314/pydantic_core-2.18.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ae0a8a797a5e56c053610fa7be147993fe50960fa43609ff2a9552b0e07013e8",
-              "url": "https://files.pythonhosted.org/packages/29/d9/96651085f19d96ef180743fabf2341b72265ddc29a41c184cfe4b1f9e97f/pydantic_core-2.18.2-cp39-cp39-macosx_10_12_x86_64.whl"
+              "hash": "77450e6d20016ec41f43ca4a6c63e9fdde03f0ae3fe90e7c27bdbeaece8b1ed4",
+              "url": "https://files.pythonhosted.org/packages/61/48/d392f839c2183a0408ef5f3455ffd8ebc21f3df2fbd3eecd7c7a9eee0ac7/pydantic_core-2.18.4-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6132dd3bd52838acddca05a72aafb6eab6536aa145e923bb50f45e78b7251043",
-              "url": "https://files.pythonhosted.org/packages/30/49/397da3f6910d62f092684a50bcaba2566825c6eee27a743846583a01fadf/pydantic_core-2.18.2-cp312-cp312-macosx_11_0_arm64.whl"
+              "hash": "b2ebef0e0b4454320274f5e83a41844c63438fdc874ea40a8b5b4ecb7693f1c4",
+              "url": "https://files.pythonhosted.org/packages/6c/a2/229dbee765ce711cd42c056da497ca26f7267384362e6767ab3bcdafca79/pydantic_core-2.18.4-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2728b01246a3bba6de144f9e3115b532ee44bd6cf39795194fb75491824a1413",
-              "url": "https://files.pythonhosted.org/packages/38/9d/0b2b5ddacf7641f6aacf04508c92afde7179c564a7aa1eeddb6dd8a16d82/pydantic_core-2.18.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "e85637bc8fe81ddb73fda9e56bab24560bdddfa98aa64f87aaa4e4b6730c23d2",
+              "url": "https://files.pythonhosted.org/packages/70/97/64968701368ff84049f5c916f63e39d6afc15cbdb188fd9f412cba359ff4/pydantic_core-2.18.4-cp311-cp311-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f93a8a2e3938ff656a7c1bc57193b1319960ac015b6e87d76c76bf14fe0244b4",
-              "url": "https://files.pythonhosted.org/packages/3a/56/832873de33c5dbd73e084f50ebe933c62946b8f14d7d05be9e2d61862cd4/pydantic_core-2.18.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl"
+              "hash": "564d7922e4b13a16b98772441879fcdcbe82ff50daa622d681dd682175ea918c",
+              "url": "https://files.pythonhosted.org/packages/73/c8/784718a31831eda4446ba3d5c9d9a259a10d01f71f9684300f1bbac65d2f/pydantic_core-2.18.4-cp312-cp312-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b14d82cdb934e99dda6d9d60dc84a24379820176cc4a0d123f88df319ae9c150",
-              "url": "https://files.pythonhosted.org/packages/3a/a7/fd69b88ea7d2e31d4dce763182349bea5d9f00184d29cde2a8d0e0375704/pydantic_core-2.18.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "847a35c4d58721c5dc3dba599878ebbdfd96784f3fb8bb2c356e123bdcd73f34",
+              "url": "https://files.pythonhosted.org/packages/79/7b/a4f002cf3603672de868ae913dec7d561509bcd17401f4cc719ab8a46213/pydantic_core-2.18.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "223ee893d77a310a0391dca6df00f70bbc2f36a71a895cecd9a0e762dc37b349",
-              "url": "https://files.pythonhosted.org/packages/3b/57/0ae73188748e11a41e50f7b1093141c67038aaccd823b0736f788daa17de/pydantic_core-2.18.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "97736815b9cc893b2b7f663628e63f436018b75f44854c8027040e05230eeddb",
+              "url": "https://files.pythonhosted.org/packages/81/f3/0e4fac63e28d03e311d2b80e9aecbe7c42fbc72d5eab5c4cc89126f74dc7/pydantic_core-2.18.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b89ed9eb7d616ef5714e5590e6cf7f23b02d0d539767d33561e3675d6f9e3857",
-              "url": "https://files.pythonhosted.org/packages/44/9b/958a08ce6203a2de9ee99a97b61a6a8f9a3263702fbaf1e1eb99646f3c8f/pydantic_core-2.18.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl"
+              "hash": "6891a2ae0e8692679c07728819b6e2b822fb30ca7445f67bbf6509b25a96332c",
+              "url": "https://files.pythonhosted.org/packages/83/0c/0b04bede6cfefe56702ae4ac9683d08d43e5ee59a03afdb8573949357e63/pydantic_core-2.18.4-cp310-cp310-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1a388a77e629b9ec814c1b1e6b3b595fe521d2cdc625fcca26fbc2d44c816804",
-              "url": "https://files.pythonhosted.org/packages/50/91/fe3547f04e5a8aad7ea11246bb7e73d42988c59e5ef4c1e4bb58024b60dc/pydantic_core-2.18.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "0eb2a4f660fcd8e2b1c90ad566db2b98d7f3f4717c64fe0a83e0adb39766d5b8",
+              "url": "https://files.pythonhosted.org/packages/83/f8/9d59e352b3d168984b2e67e347365afe9698f08b2167e9582a03abf4f961/pydantic_core-2.18.4-cp312-cp312-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ccdd111c03bfd3666bd2472b674c6899550e09e9f298954cfc896ab92b5b0e6d",
-              "url": "https://files.pythonhosted.org/packages/58/6d/e3c052741db91265b21faf8f3bdc960da6459ff03486f98ea50472c669ce/pydantic_core-2.18.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+              "hash": "f85d05aa0918283cf29a30b547b4df2fbb56b45b135f9e35b6807cb28bc47951",
+              "url": "https://files.pythonhosted.org/packages/90/2b/c06dbed36bcb247412de81a20931e42ebf6ddb6f1cf3efb28c6539358aef/pydantic_core-2.18.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cc1cfd88a64e012b74e94cd00bbe0f9c6df57049c97f02bb07d39e9c852e19a4",
-              "url": "https://files.pythonhosted.org/packages/5d/61/bfc32484eac102051ef85f5e648c9777f57398c83e5f87e3c0a420a6550b/pydantic_core-2.18.2-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "98906207f29bc2c459ff64fa007afd10a8c8ac080f7e4d5beff4c97086a3dabd",
+              "url": "https://files.pythonhosted.org/packages/90/63/9bf4ff4e014942387cb18a9d60d3b32ac892df9581b2b09c0d3eadd88fab/pydantic_core-2.18.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2b8ed04b3582771764538f7ee7001b02e1170223cf9b75dff0bc698fadb00cf3",
-              "url": "https://files.pythonhosted.org/packages/5d/c0/28331aab3be69f407a95b629be253b57c3df492ea1dd1c53dce9796d10c1/pydantic_core-2.18.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "d323a01da91851a4f17bf592faf46149c9169d68430b3146dcba2bb5e5719abc",
+              "url": "https://files.pythonhosted.org/packages/93/ea/a1f7f8ec6f85566fff4e5848622d39bf52bd4ce4cb9f3e5e5d7bc1fe78ba/pydantic_core-2.18.4-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "20aca1e2298c56ececfd8ed159ae4dde2df0781988c97ef77d5c16ff4bd5b400",
-              "url": "https://files.pythonhosted.org/packages/61/9d/5b8cb4b76b3ce1d54235e731d774c52095402d1f3726991b4d3087058688/pydantic_core-2.18.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "8951eee36c57cd128f779e641e21eb40bc5073eb28b2d23f33eb0ef14ffb3f5d",
+              "url": "https://files.pythonhosted.org/packages/9a/a6/b06114fcde6ec41aa5be8dcae863b7badffa75fbd77a4aba0847df4448ff/pydantic_core-2.18.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e25add29b8f3b233ae90ccef2d902d0ae0432eb0d45370fe315d1a5cf231004b",
-              "url": "https://files.pythonhosted.org/packages/66/db/e29a0f9aac5e0fc26fd481a39ab8343109b8eab7a7ab5de7368b73bbc708/pydantic_core-2.18.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              "hash": "4b06beb3b3f1479d32befd1f3079cc47b34fa2da62457cdf6c963393340b56e9",
+              "url": "https://files.pythonhosted.org/packages/a0/d7/05be10426e0a338a84dc2699c143d8d1a3ad2a79aefe0dd0ce17a7dea81d/pydantic_core-2.18.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2334ce8c673ee93a1d6a65bd90327588387ba073c17e61bf19b4fd97d688d63c",
-              "url": "https://files.pythonhosted.org/packages/6c/62/addd57ec1778d2b2e780386ce1a69dae1e2b6bd0dfafdb14e3d8a2121f28/pydantic_core-2.18.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+              "hash": "bc4ff9805858bd54d1a20efff925ccd89c9d2e7cf4986144b30802bf78091c3e",
+              "url": "https://files.pythonhosted.org/packages/a5/a9/8812dc9e573037eae07a7e42c4acaf3f0ce4e3c0430413727594da702f11/pydantic_core-2.18.4-cp310-cp310-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d7d904828195733c183d20a54230c0df0eb46ec746ea1a666730787353e87182",
-              "url": "https://files.pythonhosted.org/packages/6d/e0/1d65ae0cab571cf072b23a44bb3a4f0b4d45572e2157bce9f073e703e30b/pydantic_core-2.18.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "2f5966897e5461f818e136b8451d0551a2e77259eb0f73a837027b47dc95dab9",
+              "url": "https://files.pythonhosted.org/packages/ad/07/25167289bfb595cbe2aba706aa5c50083cff618662776d696e8574f03fc5/pydantic_core-2.18.4-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f0a21cbaa69900cbe1a2e7cad2aa74ac3cf21b10c3efb0fa0b80305274c0e8a2",
-              "url": "https://files.pythonhosted.org/packages/79/b8/8be6e21881344ab91df49dcd6f7ef34729c2868019f503699b2724f4195a/pydantic_core-2.18.2-cp310-cp310-macosx_11_0_arm64.whl"
+              "hash": "3c40d4eaad41f78e3bbda31b89edc46a3f3dc6e171bf0ecf097ff7a0ffff7cb1",
+              "url": "https://files.pythonhosted.org/packages/bc/36/c3e7665d84f692b095d11e9f4af71bfc339471b7153d22a7526584b75b92/pydantic_core-2.18.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c4fcf5cd9c4b655ad666ca332b9a081112cd7a58a8b5a6ca7a3104bc950f2038",
-              "url": "https://files.pythonhosted.org/packages/7c/53/f75c583e1a9508f6ed660bda7ba8623d61e47446e24b6a7f6463ba6f0ecb/pydantic_core-2.18.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "e00a3f196329e08e43d99b79b286d60ce46bed10f2280d25a1718399457e06be",
+              "url": "https://files.pythonhosted.org/packages/be/44/18eec2ac121e195662ac0f48c9c2a7bc9e2175edf408004b42adfadfc095/pydantic_core-2.18.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "470b94480bb5ee929f5acba6995251ada5e059a5ef3e0dfc63cca287283ebfa6",
-              "url": "https://files.pythonhosted.org/packages/80/b8/b93d756b36425f7ad378dcb9fdf5f6a03b88afaae0476f7bdb31dd8964be/pydantic_core-2.18.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "578e24f761f3b425834f297b9935e1ce2e30f51400964ce4801002435a1b41ef",
+              "url": "https://files.pythonhosted.org/packages/c3/3f/9669fd933f5e344e811193438ba688f7abe0c64beddd8ee52fa53dad68d0/pydantic_core-2.18.4-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9b5155ff768083cb1d62f3e143b49a8a3432e6789a3abee8acd005c3c7af1c74",
-              "url": "https://files.pythonhosted.org/packages/85/01/b70714556028799f5bf116164737f88c6cc678d788face8f57bbe16e4739/pydantic_core-2.18.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "21a5e440dbe315ab9825fcd459b8814bb92b27c974cbc23c3e8baa2b76890077",
+              "url": "https://files.pythonhosted.org/packages/c8/91/4bbb89ef7aade8095bbb26055c16d8026a3bbe97f6ad9a827f8265c00350/pydantic_core-2.18.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "22057013c8c1e272eb8d0eebc796701167d8377441ec894a8fed1af64a0bf399",
-              "url": "https://files.pythonhosted.org/packages/85/3d/ee69bb968c6e110a487b87399c036de187e3a60b9269e6fb15813204ef79/pydantic_core-2.18.2-cp39-cp39-musllinux_1_1_aarch64.whl"
+              "hash": "4d0dcc59664fcb8974b356fe0a18a672d6d7cf9f54746c05f43275fc48636851",
+              "url": "https://files.pythonhosted.org/packages/ca/14/d885398b4402c76da93df7034f2baaba56abc3ed432696a2d3ccbf9806da/pydantic_core-2.18.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "75250dbc5290e3f1a0f4618db35e51a165186f9034eff158f3d490b3fed9f8a0",
-              "url": "https://files.pythonhosted.org/packages/85/df/0adda842d84e7ca290cb01df7e33dee6463b01be0fa3171a38ceb7b1a21e/pydantic_core-2.18.2-cp311-cp311-musllinux_1_1_aarch64.whl"
+              "hash": "59ff3e89f4eaf14050c8022011862df275b552caef8082e37b542b066ce1ff26",
+              "url": "https://files.pythonhosted.org/packages/d1/ef/cf649d5e67a6baf6f5a745f7848484dd72b3b08896c1643cc54685937e52/pydantic_core-2.18.4-cp310-cp310-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "042473b6280246b1dbf530559246f6842b56119c2926d1e52b631bdc46075f2a",
-              "url": "https://files.pythonhosted.org/packages/8c/91/290e2ec9fc2c870c1c0f97772ed97dfd784b5b0d04632fa9d390a5fb6562/pydantic_core-2.18.2-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "19894b95aacfa98e7cb093cd7881a0c76f55731efad31073db4521e2b6ff5b7d",
+              "url": "https://files.pythonhosted.org/packages/d2/71/3c9fd032695746c63fd95ea2765709c12d02e5332c9cc3972fa335e9f254/pydantic_core-2.18.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0098300eebb1c837271d3d1a2cd2911e7c11b396eac9661655ee524a7f10587b",
-              "url": "https://files.pythonhosted.org/packages/95/77/8566320736c8f570e7dd35a770c9ddbab9ba0080e2d43daa714ee664a4ed/pydantic_core-2.18.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl"
+              "hash": "0fbbdc827fe5e42e4d196c746b890b3d72876bdbf160b0eafe9f0334525119c8",
+              "url": "https://files.pythonhosted.org/packages/d6/4b/51141c5ea1874e7204efac93899eefcb690ff6772a92c9a6521b32e5b71f/pydantic_core-2.18.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a8309f67285bdfe65c372ea3722b7a5642680f3dba538566340a9d36e920b5f0",
-              "url": "https://files.pythonhosted.org/packages/96/a1/286da6cf6de872add034dc3056c25f4a67189bc5a0fa939bec67a66da266/pydantic_core-2.18.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "01dd777215e2aa86dfd664daed5957704b769e726626393438f9c87690ce78c3",
+              "url": "https://files.pythonhosted.org/packages/d8/36/5676d758ccb008de9ae48db1614ffaa381e1971677e4a7e365cb7004e61c/pydantic_core-2.18.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0680b1f1f11fda801397de52c36ce38ef1c1dc841a0927a94f226dea29c3ae3d",
-              "url": "https://files.pythonhosted.org/packages/98/39/64d390ddb250456bdcc5e578a10609d6c8e1e74f729ba5be2e6d61f070f1/pydantic_core-2.18.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "574d92eac874f7f4db0ca653514d823a0d22e2354359d0759e3f6a406db5d55d",
+              "url": "https://files.pythonhosted.org/packages/d8/a2/60588397688bbc2f720c987691656e2d667b8b8776da1726bad2960a0889/pydantic_core-2.18.4-pp310-pypy310_pp73-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7ca4ae5a27ad7a4ee5170aebce1574b375de390bc01284f87b18d43a3984df72",
-              "url": "https://files.pythonhosted.org/packages/a1/c9/7d61469af6386e5846b5864bb93dc770979968c113863f923916c1a8bca2/pydantic_core-2.18.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "6f5c4d41b2771c730ea1c34e458e781b18cc668d194958e0112455fff4e402b2",
+              "url": "https://files.pythonhosted.org/packages/e0/37/a46d4741a88f7223ef3ec68490e638fb93570127f28fd76cbc2c89c0a7ec/pydantic_core-2.18.4-cp312-cp312-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "553ef617b6836fc7e4df130bb851e32fe357ce36336d897fd6646d6058d980af",
-              "url": "https://files.pythonhosted.org/packages/a6/a5/c351d83454267964d24b79e9116d716157071df4682f865d1274235a0cac/pydantic_core-2.18.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "4748321b5078216070b151d5271ef3e7cc905ab170bbfd27d5c83ee3ec436695",
+              "url": "https://files.pythonhosted.org/packages/e5/84/864556db336393f2433eda50b7e047a8d485b95dd48d1d277750ce0042bf/pydantic_core-2.18.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ef26c9e94a8c04a1b2924149a9cb081836913818e55681722d7f29af88fe7b38",
-              "url": "https://files.pythonhosted.org/packages/a9/00/858c784161dd9f56a3e0707d76c1d75155478b944b6013e1a8f94d98f3e2/pydantic_core-2.18.2-cp310-cp310-musllinux_1_1_x86_64.whl"
+              "hash": "2fdf2156aa3d017fddf8aea5adfba9f777db1d6022d392b682d2a8329e087cef",
+              "url": "https://files.pythonhosted.org/packages/e9/93/46f546b40aba72683032c167aef9ccd568a54e28f28687081d10a6735294/pydantic_core-2.18.4-cp312-cp312-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "886eec03591b7cf058467a70a87733b35f44707bd86cf64a615584fd72488b7c",
-              "url": "https://files.pythonhosted.org/packages/af/b2/dff1a30e6c7eae5e12ed90fc790733cda91d5d9d8da86db59c41359049d5/pydantic_core-2.18.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "6e5c584d357c4e2baf0ff7baf44f4994be121e16a2c88918a5817331fc7599d7",
-              "url": "https://files.pythonhosted.org/packages/b1/db/1514ac349cd12322414809f437bd709ccbb04526cc004d3dbb59de057593/pydantic_core-2.18.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "e18609ceaa6eed63753037fc06ebb16041d17d28199ae5aba0052c51449650a9",
-              "url": "https://files.pythonhosted.org/packages/bb/23/c31edf3fb5fbc4c110fb81fe78ab49c3b1030759a84341e3edd26997ac35/pydantic_core-2.18.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "e1b395e58b10b73b07b7cf740d728dd4ff9365ac46c18751bf8b3d8cca8f625a",
-              "url": "https://files.pythonhosted.org/packages/bf/ee/ed202783cd3149af4fc5d252471f24bd63c40e77451bcb6405cdea711fb9/pydantic_core-2.18.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "c9bd70772c720142be1020eac55f8143a34ec9f82d75a8e7a07852023e46617f",
-              "url": "https://files.pythonhosted.org/packages/c6/79/a9bde518a69b983adab265a1a3fbe26392b50854b1cf3f8ad030b28972c4/pydantic_core-2.18.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "95b9d5e72481d3780ba3442eac863eae92ae43a5f3adb5b4d0a1de89d42bb250",
-              "url": "https://files.pythonhosted.org/packages/c8/00/b67d95bdc8796f176e17049d160389f27f62836864afe2a6aceb50b82732/pydantic_core-2.18.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "3a6515ebc6e69d85502b4951d89131ca4e036078ea35533bb76327f8424531ce",
-              "url": "https://files.pythonhosted.org/packages/cd/df/4c68db027a30a8a4ef56ab28e9024b9973dc869695d9a7118724f8b32c5e/pydantic_core-2.18.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "219da3f096d50a157f33645a1cf31c0ad1fe829a92181dd1311022f986e5fbe3",
-              "url": "https://files.pythonhosted.org/packages/ce/9c/6ba3121fecd4c8a0ae48d87e02a87d97ec8831eb978c53bcbfa0b2e43600/pydantic_core-2.18.2-cp311-cp311-macosx_10_12_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "05b7133a6e6aeb8df37d6f413f7705a37ab4031597f64ab56384c94d98fa0e90",
-              "url": "https://files.pythonhosted.org/packages/cf/f0/eb883cfa0de1ec85e4e388db092e6e0297c54bfe27b3015fe4a2d82f639d/pydantic_core-2.18.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "43f0f463cf89ace478de71a318b1b4f05ebc456a9b9300d027b4b57c1a2064fb",
-              "url": "https://files.pythonhosted.org/packages/d1/78/2eebdd02b56aab4fa53027721c56f1e5bd8480c1f54270036ff396938ac7/pydantic_core-2.18.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "4b4356d3538c3649337df4074e81b85f0616b79731fe22dd11b99499b2ebbdf3",
-              "url": "https://files.pythonhosted.org/packages/d4/8f/51b3cb36a4d2f1ed5d72f3ea329bab203db234fff056414b76950f353984/pydantic_core-2.18.2-cp312-cp312-musllinux_1_1_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "9e08e867b306f525802df7cd16c44ff5ebbe747ff0ca6cf3fde7f36c05a59a81",
-              "url": "https://files.pythonhosted.org/packages/d8/3d/ae9491c1f071f7f49c8bc7b161325e658ea53f72a12ec5fd7a4ea4fa01ee/pydantic_core-2.18.2-cp310-cp310-macosx_10_12_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "cbca948f2d14b09d20268cda7b0367723d79063f26c4ffc523af9042cad95592",
-              "url": "https://files.pythonhosted.org/packages/d9/00/12e43635644f989890b84be94618e79f0e50c368f0b56e80282fb2e49f14/pydantic_core-2.18.2-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "997abc4df705d1295a42f95b4eec4950a37ad8ae46d913caeee117b6b198811c",
-              "url": "https://files.pythonhosted.org/packages/e1/37/046c7a966fc44b52a015be11b9ba99a0c5401770bbd0f69c84fa6d5957c1/pydantic_core-2.18.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "2e29d20810dfc3043ee13ac7d9e25105799817683348823f305ab3f349b9386e",
-              "url": "https://files.pythonhosted.org/packages/e9/23/a609c50e53959eb96393e42ae4891901f699aaad682998371348650a6651/pydantic_core-2.18.2.tar.gz"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "75f7e9488238e920ab6204399ded280dc4c307d034f3924cd7f90a38b1829563",
-              "url": "https://files.pythonhosted.org/packages/ef/ee/8606de130aa729e3442b3ff09d07c991b779ec6483db122e96d5c4ba3686/pydantic_core-2.18.2-cp310-cp310-musllinux_1_1_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "3f9a801e7c8f1ef8718da265bba008fa121243dfe37c1cea17840b0944dfd72c",
-              "url": "https://files.pythonhosted.org/packages/f2/1e/f0fc4e097aa6627b277d600886b89e5ba129fd31eb8cfce00a358b33eed1/pydantic_core-2.18.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "a1874c6dd4113308bd0eb568418e6114b252afe44319ead2b4081e9b9521fe75",
-              "url": "https://files.pythonhosted.org/packages/fc/67/68ea4de2c7f73bcf3634508a80a4a35a38d56932a3c5e7cd70b58e62bf34/pydantic_core-2.18.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl"
+              "hash": "43d447dd2ae072a0065389092a231283f62d960030ecd27565672bd40746c507",
+              "url": "https://files.pythonhosted.org/packages/f4/63/97d408a298a21e41585372add1f0a2d902a46c0f7b3c8e8386b22429bb17/pydantic_core-2.18.4-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
             }
           ],
           "project_name": "pydantic-core",
@@ -1799,19 +1865,52 @@
             "typing-extensions!=4.7.0,>=4.6.0"
           ],
           "requires_python": ">=3.8",
-          "version": "2.18.2"
+          "version": "2.18.4"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1733f0620f6cda4095bbf0d9ff8022486e91892245bb9e7d5542c018f612f233",
-              "url": "https://files.pythonhosted.org/packages/c4/43/6b1debd95ecdf001bc46789a933f658da3f9738c65f32db3f4e8f2a4ca97/pytest-8.2.0-py3-none-any.whl"
+              "hash": "59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320",
+              "url": "https://files.pythonhosted.org/packages/2b/4f/e04a8067c7c96c364cef7ef73906504e2f40d690811c021e1a1901473a19/PyJWT-2.8.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d507d4482197eac0ba2bae2e9babf0672eb333017bcedaa5fb1a3d42c1174b3f",
-              "url": "https://files.pythonhosted.org/packages/09/9d/78b3785134306efe9329f40815af45b9215068d6ae4747ec0bc91ff1f4aa/pytest-8.2.0.tar.gz"
+              "hash": "57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de",
+              "url": "https://files.pythonhosted.org/packages/30/72/8259b2bccfe4673330cea843ab23f86858a419d8f1493f66d413a76c7e3b/PyJWT-2.8.0.tar.gz"
+            }
+          ],
+          "project_name": "pyjwt",
+          "requires_dists": [
+            "coverage[toml]==5.0.4; extra == \"dev\"",
+            "coverage[toml]==5.0.4; extra == \"tests\"",
+            "cryptography>=3.4.0; extra == \"crypto\"",
+            "cryptography>=3.4.0; extra == \"dev\"",
+            "pre-commit; extra == \"dev\"",
+            "pytest<7.0.0,>=6.0.0; extra == \"dev\"",
+            "pytest<7.0.0,>=6.0.0; extra == \"tests\"",
+            "sphinx-rtd-theme; extra == \"dev\"",
+            "sphinx-rtd-theme; extra == \"docs\"",
+            "sphinx<5.0.0,>=4.5.0; extra == \"dev\"",
+            "sphinx<5.0.0,>=4.5.0; extra == \"docs\"",
+            "typing-extensions; python_version <= \"3.7\"",
+            "zope.interface; extra == \"dev\"",
+            "zope.interface; extra == \"docs\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "2.8.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "c434598117762e2bd304e526244f67bf66bbd7b5d6cf22138be51ff661980343",
+              "url": "https://files.pythonhosted.org/packages/4e/e7/81ebdd666d3bff6670d27349b5053605d83d55548e6bd5711f3b0ae7dd23/pytest-8.2.2-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "de4bb8104e201939ccdc688b27a89a7be2079b22e2bd2b07f806b6ba71117977",
+              "url": "https://files.pythonhosted.org/packages/a6/58/e993ca5357553c966b9e73cb3475d9c935fe9488746e13ebdf9b80fae508/pytest-8.2.2.tar.gz"
             }
           ],
           "project_name": "pytest",
@@ -1832,7 +1931,7 @@
             "xmlschema; extra == \"dev\""
           ],
           "requires_python": ">=3.8",
-          "version": "8.2.0"
+          "version": "8.2.2"
         },
         {
           "artifacts": [
@@ -1858,288 +1957,231 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "623883fb78e692d54ed7c43b09beec52c6685f10a45a7518128e25746667403b",
-              "url": "https://files.pythonhosted.org/packages/96/76/6c36a243af1bc27e933603beacf46ef1ae994011faa994d9a4faf65bcd7d/rapidfuzz-3.9.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319",
+              "url": "https://files.pythonhosted.org/packages/9c/3d/a121f284241f08268b21359bd425f7d4825cffc5ac5cd0e1b3d82ffd2b10/pytz-2024.1-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5c396562d304e974b4b0d5cd3afc4f92c113ea46a36e6bc62e45333d6aa8837e",
-              "url": "https://files.pythonhosted.org/packages/08/ab/f01f86bf1a5f23a4ec305c66d862c717693407e58f6e27c41fbd6a4733a1/rapidfuzz-3.9.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812",
+              "url": "https://files.pythonhosted.org/packages/90/26/9f1f00a5d021fff16dee3de13d43e5e978f3d58928e129c3a62cf7eb9738/pytz-2024.1.tar.gz"
+            }
+          ],
+          "project_name": "pytz",
+          "requires_dists": [],
+          "requires_python": null,
+          "version": "2024.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "41a81a9f311dc83d22661f9b1a1de983b201322df0c4554042ffffd0f2040c37",
+              "url": "https://files.pythonhosted.org/packages/af/11/dca6cb19b0da3253d1bab5c2547667daff99934e5312382ad5da115d341c/rapidfuzz-3.9.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "633b9d03fc04abc585c197104b1d0af04b1f1db1abc99f674d871224cd15557a",
-              "url": "https://files.pythonhosted.org/packages/09/d3/a26f74b77545e2d5f58ccd1cbcf13f96b8fcef1e99b11a4fa9cc719f3878/rapidfuzz-3.9.0-cp312-cp312-macosx_10_9_x86_64.whl"
+              "hash": "afe7c72d3f917b066257f7ff48562e5d462d865a25fbcabf40fca303a9fa8d35",
+              "url": "https://files.pythonhosted.org/packages/05/ca/1976eab38fd8b77b1cbb3390f59de04eb1ab91bf8736ff8f0fd41cb9cb92/rapidfuzz-3.9.3-cp312-cp312-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0bb28ab5300cf974c7eb68ea21125c493e74b35b1129e629533468b2064ae0a2",
-              "url": "https://files.pythonhosted.org/packages/0a/d4/867e918affe9e788fd12857e62565b558f82f1a525a59bf637bde33bf0de/rapidfuzz-3.9.0-cp310-cp310-musllinux_1_1_x86_64.whl"
+              "hash": "5d6a210347d6e71234af5c76d55eeb0348b026c9bb98fe7c1cca89bac50fb734",
+              "url": "https://files.pythonhosted.org/packages/0a/60/cc226a3e7bb8809bc7aaad1ebab2ebd615b78252232a38ae41c1f39ab39a/rapidfuzz-3.9.3-cp312-cp312-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0ca799f882364e69d0872619afb19efa3652b7133c18352e4a3d86a324fb2bb1",
-              "url": "https://files.pythonhosted.org/packages/0f/0f/96f6f10db440b4208c47eaa4c34a8ec8315e5388bad678e1c454d3c27303/rapidfuzz-3.9.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "b300708c917ce52f6075bdc6e05b07c51a085733650f14b732c087dc26e0aaad",
+              "url": "https://files.pythonhosted.org/packages/11/8c/f83bb24d1961ef9124c5491dfcc678426d9f7e3025207de824cdac056642/rapidfuzz-3.9.3-cp312-cp312-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f83bd3d01f04061c3660742dc85143a89d49fd23eb31eccbf60ad56c4b955617",
-              "url": "https://files.pythonhosted.org/packages/10/15/8cf5790ffbe3548b9dfe5d77afd0e0244d5c1fae05c6753679d13f724075/rapidfuzz-3.9.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "754b719a4990735f66653c9e9261dcf52fd4d925597e43d6b9069afcae700d21",
+              "url": "https://files.pythonhosted.org/packages/13/b2/8f6956ccfadff4193f4fa2a93e0c0f460d0521d925654a64f3751dd018a6/rapidfuzz-3.9.3-cp311-cp311-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2bc5559b9b94326922c096b30ae2d8e5b40b2e9c2c100c2cc396ad91bcb84d30",
-              "url": "https://files.pythonhosted.org/packages/15/5e/b2cc20248521b59ff94c01861dd3db7586d100ddbe0962339cf6d9e2b27f/rapidfuzz-3.9.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "959a15186d18425d19811bea86a8ffbe19fd48644004d29008e636631420a9b7",
+              "url": "https://files.pythonhosted.org/packages/16/51/6b072763ae87580ddf3600beda439d360662a234e6334dbc901bca7f5e2c/rapidfuzz-3.9.3-cp310-cp310-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1179dcd3d150a67b8a678cd9c84f3baff7413ff13c9e8fe85e52a16c97e24c9b",
-              "url": "https://files.pythonhosted.org/packages/1d/3e/bce7e686d05ca118ec5f5d674deb6e2fdd4929d98ec2dcd565f41e2c22cd/rapidfuzz-3.9.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "53e06e4b81f552da04940aa41fc556ba39dee5513d1861144300c36c33265b76",
+              "url": "https://files.pythonhosted.org/packages/23/6e/518ff1f9c85cfae46bb9ad27053ce65e1f742492f29223dff8a7edfcfa60/rapidfuzz-3.9.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b182f0fb61f6ac435e416eb7ab330d62efdbf9b63cf0c7fa12d1f57c2eaaf6f3",
-              "url": "https://files.pythonhosted.org/packages/29/91/81aeb149fdcaac4682f6003741530ceaf9a85d90dc21a01a5849acb9c2fe/rapidfuzz-3.9.0.tar.gz"
+              "hash": "5c7ca5b6050f18fdcacdada2dc5fb7619ff998cd9aba82aed2414eee74ebe6cd",
+              "url": "https://files.pythonhosted.org/packages/2d/5e/4539f4e2603ed557be8db700925a059753334183561243b9f8adb75cd85a/rapidfuzz-3.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b11e602987bcb4ea22b44178851f27406fca59b0836298d0beb009b504dba266",
-              "url": "https://files.pythonhosted.org/packages/2c/93/2234aa2dd6991648999cd245c28859561edd85b6d4b508dc3630179ef9df/rapidfuzz-3.9.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "5410dc848c947a603792f4f51b904a3331cf1dc60621586bfbe7a6de72da1091",
+              "url": "https://files.pythonhosted.org/packages/2f/3f/7a5bf238c3fe509aa33426e6069a7f00d222ab01759aeb1232aecbe8d813/rapidfuzz-3.9.3-pp310-pypy310_pp73-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "488f74126904db6b1bea545c2f3567ea882099f4c13f46012fe8f4b990c683df",
-              "url": "https://files.pythonhosted.org/packages/2c/f2/312832a50999bb349d8818cc1835cf57d55d0d518da02058347475ee6dd6/rapidfuzz-3.9.0-cp310-cp310-macosx_11_0_arm64.whl"
+              "hash": "5e33f779391caedcba2ba3089fb6e8e557feab540e9149a5c3f7fea7a3a7df37",
+              "url": "https://files.pythonhosted.org/packages/35/6b/1a9dfd55de5ab6d792d82089b19b63f6519efe8451d21386e816125df4c6/rapidfuzz-3.9.3-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ce897b5dafb7fb7587a95fe4d449c1ea0b6d9ac4462fbafefdbbeef6eee4cf6a",
-              "url": "https://files.pythonhosted.org/packages/33/61/9b1097ce2e74e4a61527cda0c6f26dae968d253d3d32a4b04983023d4362/rapidfuzz-3.9.0-cp39-cp39-musllinux_1_1_ppc64le.whl"
+              "hash": "3e6d27dad8c990218b8cd4a5c99cbc8834f82bb46ab965a7265d5aa69fc7ced7",
+              "url": "https://files.pythonhosted.org/packages/38/a2/4e3ce32e17895a581d570db545b599ab153dbcf19f3429537dfe8697a7e8/rapidfuzz-3.9.3-cp311-cp311-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "47b7c0840afa724db3b1a070bc6ed5beab73b4e659b1d395023617fc51bf68a2",
-              "url": "https://files.pythonhosted.org/packages/3c/28/1ea39153402c46e0b6e1eb894fbab86b4912d440d411bad921bcf0d3cf51/rapidfuzz-3.9.0-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "fd84b7f652a5610733400307dc732f57c4a907080bef9520412e6d9b55bc9adc",
+              "url": "https://files.pythonhosted.org/packages/44/7c/32cf135edc31a114d87c0ab4a7529f2e2f303e43306dbef8b29246fc2ddd/rapidfuzz-3.9.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "47d97e28c42f1efb7781993b67c749223f198f6653ef177a0c8f2b1c516efcaf",
-              "url": "https://files.pythonhosted.org/packages/40/18/0322dde84dd04e7a9c21e8552302326ffed5f5bda3b9153e3a7b3e00c476/rapidfuzz-3.9.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "8319838fb5b7b5f088d12187d91d152b9386ce3979ed7660daa0ed1bff953791",
+              "url": "https://files.pythonhosted.org/packages/46/e0/7b0f506b32d648b837373f110d3e6694366a81efa2dd4bc3faa1bc6c2bf2/rapidfuzz-3.9.3-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "65d9250a4b0bf86320097306084bc3ca479c8f5491927c170d018787793ebe95",
-              "url": "https://files.pythonhosted.org/packages/42/e5/1b1f0a1434b2b18699ca618a00cc906fac8a34836c51addc36294c95da2d/rapidfuzz-3.9.0-cp39-cp39-macosx_10_9_universal2.whl"
+              "hash": "f57e8305c281e8c8bc720515540e0580355100c0a7a541105c6cafc5de71daae",
+              "url": "https://files.pythonhosted.org/packages/4f/ec/1fa416c3ad850f21b2802e6c0497789782d8392feade74c9d15faa935041/rapidfuzz-3.9.3-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a365886c42177b2beab475a50ba311b59b04f233ceaebc4c341f6f91a86a78e2",
-              "url": "https://files.pythonhosted.org/packages/43/ad/ffcba825b1817b3908393610b3165c1e87919bad4cba68235df3f9f5e48e/rapidfuzz-3.9.0-cp39-cp39-musllinux_1_1_i686.whl"
+              "hash": "b398ea66e8ed50451bce5997c430197d5e4b06ac4aa74602717f792d8d8d06e2",
+              "url": "https://files.pythonhosted.org/packages/50/b9/22b4848fc842b17c4446433d5d472007c9799dbe8dd90bc0f6d60767c29d/rapidfuzz-3.9.3.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "2003071aa633477a01509890c895f9ef56cf3f2eaa72c7ec0b567f743c1abcba",
-              "url": "https://files.pythonhosted.org/packages/46/22/7e19ce8e0c6a4836a112e1db84c4a01fe21f152efef3651678b745923238/rapidfuzz-3.9.0-cp312-cp312-musllinux_1_1_x86_64.whl"
+              "hash": "f50fed4a9b0c9825ff37cf0bccafd51ff5792090618f7846a7650f21f85579c9",
+              "url": "https://files.pythonhosted.org/packages/51/dd/6fdff521c22436fe0dd0f604bb50f9cb6b86b21871ac0fa6b130932082bf/rapidfuzz-3.9.3-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "48105991ff6e4a51c7f754df500baa070270ed3d41784ee0d097549bc9fcb16d",
-              "url": "https://files.pythonhosted.org/packages/48/1e/41046a8d215f516e396ba9eb51b5906364022de729f5745da2758d169de6/rapidfuzz-3.9.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "bdb8c5b8e29238ec80727c2ba3b301efd45aa30c6a7001123a6647b8e6f77ea4",
+              "url": "https://files.pythonhosted.org/packages/57/64/1839dd18b34d056ea8b64bd8f6fb5a3823bb11a34132636280ecc3016932/rapidfuzz-3.9.3-cp310-cp310-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6a7f273906b3c7cc6d63a76e088200805947aa0bc1ada42c6a0e582e19c390d7",
-              "url": "https://files.pythonhosted.org/packages/4a/01/31c2faf0248d3515ffd1da7d88377179417969d9112f37414b3fc3ef0a43/rapidfuzz-3.9.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "0d055da0e801c71dd74ba81d72d41b2fa32afa182b9fea6b4b199d2ce937450d",
+              "url": "https://files.pythonhosted.org/packages/61/9d/a6d65e93c74967d534aadbc0ad9a29e40ff124c5723950916ef85ea3a1ee/rapidfuzz-3.9.3-cp310-cp310-musllinux_1_2_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ff8982fc3bd49d55a91569fc8a3feba0de4cef0b391ff9091be546e9df075b81",
-              "url": "https://files.pythonhosted.org/packages/4d/39/3d5424c663ccb19bfdc647fbcba3c322ce975a8646e567a1c52be40c1d0e/rapidfuzz-3.9.0-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "51fa1ba84653ab480a2e2044e2277bd7f0123d6693051729755addc0d015c44f",
+              "url": "https://files.pythonhosted.org/packages/67/aa/0b93dc28c71d26248ce61297698f27a7da00bdda142b82978a0e65581a5b/rapidfuzz-3.9.3-cp312-cp312-musllinux_1_2_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b33c6d4b3a1190bc0b6c158c3981535f9434e8ed9ffa40cf5586d66c1819fb4b",
-              "url": "https://files.pythonhosted.org/packages/4d/b5/d02541baa282c1762afef117b8667d96c9439b4526bd9eb13a7f55287b56/rapidfuzz-3.9.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "65f45be77ec82da32ce5709a362e236ccf801615cc7163b136d1778cf9e31b14",
+              "url": "https://files.pythonhosted.org/packages/6a/85/b405d31369711211f34aa3c6e0fc5731e37b00cbff5e0677b70be099a788/rapidfuzz-3.9.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "491274080742110427f38a6085bb12dffcaff1eef12dccf9e8758398c7e3957e",
-              "url": "https://files.pythonhosted.org/packages/52/d5/bb398eaa8f4a65fd29622e07ea176348826c6b968928f59b879cc28fbcf4/rapidfuzz-3.9.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl"
+              "hash": "153f23c03d4917f6a1fc2fb56d279cc6537d1929237ff08ee7429d0e40464a18",
+              "url": "https://files.pythonhosted.org/packages/6e/79/8c58a2d70b8e2bb53d536db89c0ca08e9e753fca98b4a864921318e11d78/rapidfuzz-3.9.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "170822a1b1719f02b58e3dce194c8ad7d4c5b39be38c0fdec603bd19c6f9cf81",
-              "url": "https://files.pythonhosted.org/packages/5c/2b/41aa779f65e86ce482bc2d4014d2f6b4f4fb55b206244aefa6d5b83e1b8a/rapidfuzz-3.9.0-cp312-cp312-musllinux_1_1_aarch64.whl"
+              "hash": "b80eb7cbe62348c61d3e67e17057cddfd6defab168863028146e07d5a8b24a89",
+              "url": "https://files.pythonhosted.org/packages/84/c2/f90f19f60b55874c1157ef8f2ef9a13a31a8be9a9dee2c71fb0559ef4df3/rapidfuzz-3.9.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bdd8c15c3a14e409507fdf0c0434ec481d85c6cbeec8bdcd342a8cd1eda03825",
-              "url": "https://files.pythonhosted.org/packages/61/5c/3425cc9a1212019c405964ca24226b28fd8907c97b725cf0fa21fdd8d0c4/rapidfuzz-3.9.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "05ee0696ebf0dfe8f7c17f364d70617616afc7dafe366532730ca34056065b8a",
+              "url": "https://files.pythonhosted.org/packages/86/13/ff32d327320dadf82b5d84a6eddf2efc264c0d7db45a04b0aea39fea3840/rapidfuzz-3.9.3-cp311-cp311-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "413ac49bae291d7e226a5c9be65c71b2630b3346bce39268d02cb3290232e4b7",
-              "url": "https://files.pythonhosted.org/packages/61/c5/2e1dbba4f2342119495ce383ad71e905ba1299d99320e21e3e2ac9da66b2/rapidfuzz-3.9.0-cp39-cp39-musllinux_1_1_s390x.whl"
+              "hash": "2bc8391749e5022cd9e514ede5316f86e332ffd3cfceeabdc0b17b7e45198a8c",
+              "url": "https://files.pythonhosted.org/packages/94/76/e9de1c3f1e7062c824a0d4ee490da24fa36ca0bd3fedc237588fde5c37e2/rapidfuzz-3.9.3-cp311-cp311-musllinux_1_2_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2444d8155d9846f206e2079bb355b85f365d9457480b0d71677a112d0a7f7128",
-              "url": "https://files.pythonhosted.org/packages/63/07/a809f41c7aaa423e817080fe6b9086b0abfdd2b021a7ce6a0e45c1d55a13/rapidfuzz-3.9.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "83ea7ca577d76778250421de61fb55a719e45b841deb769351fc2b1740763050",
+              "url": "https://files.pythonhosted.org/packages/94/de/ccfe7eb6106c851c2f754651a1e05cac07306f27d51914b2131930a087c8/rapidfuzz-3.9.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "28da953eb2ef9ad527e536022da7afff6ace7126cdd6f3e21ac20f8762e76d2c",
-              "url": "https://files.pythonhosted.org/packages/69/e5/84c571c2e2d6c28ad86e862ef8a27168cf9159d4acd4d64dfa6fbe18c160/rapidfuzz-3.9.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "dc1037507810833646481f5729901a154523f98cbebb1157ba3a821012e16402",
+              "url": "https://files.pythonhosted.org/packages/9e/04/49bbaf3c218d72b478bcfed597336659e93b72c8a7385712bbf7804fae57/rapidfuzz-3.9.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0c5b8f9a7b177af6ce7c6ad5b95588b4b73e37917711aafa33b2e79ee80fe709",
-              "url": "https://files.pythonhosted.org/packages/76/68/7e3960598f0eed4f92876f58d066ad73155e519522e4ca6e0bdc4d6721bc/rapidfuzz-3.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "c52970f7784518d7c82b07a62a26e345d2de8c2bd8ed4774e13342e4b3ff4200",
+              "url": "https://files.pythonhosted.org/packages/9f/96/8e0bd330e220e3e4d4728c8f7df6d83bc7c33da3e839a2f19940bc319d05/rapidfuzz-3.9.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "33cfabcb7fd994938a6a08e641613ce5fe46757832edc789c6a5602e7933d6fa",
-              "url": "https://files.pythonhosted.org/packages/77/c8/627b2f75513736cba1519c90d141eb11d152e497ed4143d335eccd14997d/rapidfuzz-3.9.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "a4fc7b784cf987dbddc300cef70e09a92ed1bce136f7bb723ea79d7e297fe76d",
+              "url": "https://files.pythonhosted.org/packages/ac/4d/fe74f3b300bef1cf4bb5f4e06e099384c04a9c18fa0449fccaa9bcff832b/rapidfuzz-3.9.3-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "36bf35df2d6c7d5820da20a6720aee34f67c15cd2daf8cf92e8141995c640c25",
-              "url": "https://files.pythonhosted.org/packages/80/48/74b632b3c92fc3f65c1eb0e09f73ef74a46b9ac602c89fac5c3c07ccd8e6/rapidfuzz-3.9.0-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "b777cd910ceecd738adc58593d6ed42e73f60ad04ecdb4a841ae410b51c92e0e",
+              "url": "https://files.pythonhosted.org/packages/ae/6d/7ebcc312da01373e41c5a7ca699a144e0f12ccba6fa0d0353e0974f4c95c/rapidfuzz-3.9.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "731269812ea837e0b93d913648e404736407408e33a00b75741e8f27c590caa2",
-              "url": "https://files.pythonhosted.org/packages/8e/cc/ec5cc66958a8bc377979c0c001c3d971682eb5b273886fd706ff991dd319/rapidfuzz-3.9.0-cp312-cp312-musllinux_1_1_ppc64le.whl"
+              "hash": "57e7c5bf7b61c7320cfa5dde1e60e678d954ede9bb7da8e763959b2138391401",
+              "url": "https://files.pythonhosted.org/packages/b1/65/1e576c2cb5dd3632f4bc9de2f79e3101983dca30624328a1293bb0ec9f1f/rapidfuzz-3.9.3-cp312-cp312-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "014ac55b03f4074f903248ded181f3000f4cdbd134e6155cbf643f0eceb4f70f",
-              "url": "https://files.pythonhosted.org/packages/a2/fd/7c1c471c459ff274895d7a857209316dd987f935a56300984b337952bf43/rapidfuzz-3.9.0-cp311-cp311-musllinux_1_1_i686.whl"
+              "hash": "282d55700a1a3d3a7980746eb2fcd48c9bbc1572ebe0840d0340d548a54d01fe",
+              "url": "https://files.pythonhosted.org/packages/ba/65/35818713f4fe82946e2d03f96215d76644a8da4332471f769bebd155f929/rapidfuzz-3.9.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2d267d4c982ab7d177e994ab1f31b98ff3814f6791b90d35dda38307b9e7c989",
-              "url": "https://files.pythonhosted.org/packages/a6/ed/86064e1ce0e5cc8ed51e11916284a0de3163016cd75c5c894e74335371ea/rapidfuzz-3.9.0-cp310-cp310-musllinux_1_1_s390x.whl"
+              "hash": "17ff7f7eecdb169f9236e3b872c96dbbaf116f7787f4d490abd34b0116e3e9c8",
+              "url": "https://files.pythonhosted.org/packages/bb/1e/1fe0ec38b04abbfeb5922bf611f37a2c2602f238136c0bb9dfbdd1c1d7c4/rapidfuzz-3.9.3-cp312-cp312-musllinux_1_2_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "68da1b70458fea5290ec9a169fcffe0c17ff7e5bb3c3257e63d7021a50601a8e",
-              "url": "https://files.pythonhosted.org/packages/b6/f5/4f2e8e71d6b85a11de6c0312d7e117964bfff8a292f97cfda9657177eabc/rapidfuzz-3.9.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "b8ab0fa653d9225195a8ff924f992f4249c1e6fa0aea563f685e71b81b9fcccf",
+              "url": "https://files.pythonhosted.org/packages/c7/42/7e580063d904c054ca3eb339124adf0631f5bf7c4168d05459ee319028b7/rapidfuzz-3.9.3-cp312-cp312-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "182b4e11de928fb4834e8f8b5ecd971b5b10a86fabe8636ab65d3a9b7e0e9ca7",
-              "url": "https://files.pythonhosted.org/packages/bd/b9/eee43acc9a0c26f1f415d29b1985f5fc694a600efbea3035d4d10ae61b6a/rapidfuzz-3.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "a96c5225e840f1587f1bac8fa6f67562b38e095341576e82b728a82021f26d62",
+              "url": "https://files.pythonhosted.org/packages/c8/07/db1f5c400461442f7eb0745f1e22216771e8151400cc942c255d323beef8/rapidfuzz-3.9.3-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3a16c48c6df8fb633efbbdea744361025d01d79bca988f884a620e63e782fe5b",
-              "url": "https://files.pythonhosted.org/packages/bd/ed/304d310c967b76c5f42ae0676f7fc273c462b6d4d17c44fb60973310f0ca/rapidfuzz-3.9.0-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "875b581afb29a7213cf9d98cb0f98df862f1020bce9d9b2e6199b60e78a41d14",
+              "url": "https://files.pythonhosted.org/packages/cb/ad/55d162c72cb13ecc230a9b868fc745da7a93d35cc70911042054301ddac0/rapidfuzz-3.9.3-cp310-cp310-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "905b01a9b633394ff6bb5ebb1c5fd660e0e180c03fcf9d90199cc6ed74b87cf7",
-              "url": "https://files.pythonhosted.org/packages/bf/84/a3e07222e3f48703232474844b3d0ab16ddd6a0c35af0ced7ce239820c22/rapidfuzz-3.9.0-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "87bb8d84cb41446a808c4b5f746e29d8a53499381ed72f6c4e456fe0f81c80a8",
+              "url": "https://files.pythonhosted.org/packages/d2/b4/d3112216244ac16e1240ec2470835ac61a3124b35d6fd7e068637f605eca/rapidfuzz-3.9.3-cp310-cp310-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ab872cb57ae97c54ba7c71a9e3c9552beb57cb907c789b726895576d1ea9af6f",
-              "url": "https://files.pythonhosted.org/packages/c3/db/752d2fbb7a736fe755c9490fa57fa68c6fbdb04ea62a7eb270c94d2dd008/rapidfuzz-3.9.0-cp312-cp312-macosx_11_0_arm64.whl"
+              "hash": "143caf7247449055ecc3c1e874b69e42f403dfc049fc2f3d5f70e1daf21c1318",
+              "url": "https://files.pythonhosted.org/packages/e3/23/7da49e42b933c2a00a21cb1ac52663f2b1f072b87059e6a126acae4210e5/rapidfuzz-3.9.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "55e2c5076f38fc1dbaacb95fa026a3e409eee6ea5ac4016d44fb30e4cad42b20",
-              "url": "https://files.pythonhosted.org/packages/c9/8a/13aaaa9a3b123d773bfa06e897363396bd020cd0e7af69f53df8cf7ed9d8/rapidfuzz-3.9.0-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "5b422c0a6fe139d5447a0766268e68e6a2a8c2611519f894b1f31f0a392b9167",
+              "url": "https://files.pythonhosted.org/packages/e6/f2/e49146c3b28eeb2543b6943eb984a75b463848e78c9a9b3ff73de3f2f1e5/rapidfuzz-3.9.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fc02157f521af15143fae88f92ef3ddcc4e0cff05c40153a9549dc0fbdb9adb3",
-              "url": "https://files.pythonhosted.org/packages/ca/87/30c5da5f1fead1dab51ca0c5f037d15aec9d1efb3fb2ea04df3dcbb7d318/rapidfuzz-3.9.0-cp311-cp311-musllinux_1_1_s390x.whl"
+              "hash": "a24603dd05fb4e3c09d636b881ce347e5f55f925a6b1b4115527308a323b9f8e",
+              "url": "https://files.pythonhosted.org/packages/ee/83/c69ed50e24750d5deb2d55becc8d6bdff894e0941bba6bf579b79870052f/rapidfuzz-3.9.3-cp310-cp310-musllinux_1_2_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e3f2d1ea7cd57dfcd34821e38b4924c80a31bcf8067201b1ab07386996a9faee",
-              "url": "https://files.pythonhosted.org/packages/ce/9e/9a0eb95e14baf12b760b29ce82bfc25d8cf0d009c9ceb39e82b6f986950b/rapidfuzz-3.9.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "93981895602cf5944d89d317ae3b1b4cc684d175a8ae2a80ce5b65615e72ddd0",
+              "url": "https://files.pythonhosted.org/packages/f1/e9/5e340fa359730135c9db70299d70f9426244fdf5388f4cd8b5781320fc91/rapidfuzz-3.9.3-cp311-cp311-musllinux_1_2_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8e5ff882d3a3d081157ceba7e0ebc7fac775f95b08cbb143accd4cece6043819",
-              "url": "https://files.pythonhosted.org/packages/d2/ff/b85fa640ec7e1b18cf6ec69b14bb74f3604a6b14218e44c918e82f7f856f/rapidfuzz-3.9.0-cp312-cp312-musllinux_1_1_s390x.whl"
+              "hash": "b3bd0d9632088c63a241f217742b1cf86e2e8ae573e01354775bd5016d12138c",
+              "url": "https://files.pythonhosted.org/packages/f7/14/602ab1ce3385398e1f53343b3096a1acdfb399bede18e8773bd1339df0ba/rapidfuzz-3.9.3-cp310-cp310-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e2218d62ab63f3c5ad48eced898854d0c2c327a48f0fb02e2288d7e5332a22c8",
-              "url": "https://files.pythonhosted.org/packages/d4/65/1ad391d3bb19155ab76118b5db57b0f41b17e2c52d791a9e6932d65dbf8b/rapidfuzz-3.9.0-cp311-cp311-macosx_10_9_universal2.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "0dcb95fde22f98e6d0480db8d6038c45fe2d18a338690e6f9bba9b82323f3469",
-              "url": "https://files.pythonhosted.org/packages/d7/0a/96b93ddd15ab1c39e04a20027580607e46850c743d1e6cbb014f393e9491/rapidfuzz-3.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "3083512e9bf6ed2bb3d25883922974f55e21ae7f8e9f4e298634691ae1aee583",
-              "url": "https://files.pythonhosted.org/packages/da/25/a4404e6066bfd37a2f46967b3f05663e4d2bb7a33baf542456370b2b518c/rapidfuzz-3.9.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "e721842e6b601ebbeb8cc5e12c75bbdd1d9e9561ea932f2f844c418c31256e82",
-              "url": "https://files.pythonhosted.org/packages/da/97/0395e9cf571c159439f6cba2b6724311a034695b6836c104eff1c33cf9af/rapidfuzz-3.9.0-cp310-cp310-musllinux_1_1_i686.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "ff08081c49b18ba253a99e6a47f492e6ee8019e19bbb6ddc3ed360cd3ecb2f62",
-              "url": "https://files.pythonhosted.org/packages/da/9e/004110566da8d3769a71e99cd47bf68271aaaceeb8700add2da078ecf6c0/rapidfuzz-3.9.0-cp311-cp311-musllinux_1_1_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "bd375c4830fee11d502dd93ecadef63c137ae88e1aaa29cc15031fa66d1e0abb",
-              "url": "https://files.pythonhosted.org/packages/dc/70/afeb811084694a5eb8ca50a2a353b44dd8f42cb9c4b90ca62588240be266/rapidfuzz-3.9.0-cp310-cp310-macosx_10_9_universal2.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "f81fe99a69ac8ee3fd905e70c62f3af033901aeb60b69317d1d43d547b46e510",
-              "url": "https://files.pythonhosted.org/packages/e1/53/8d1198f48bc865ff4f68406b31a85abf89e979371ceb362b691d494e960e/rapidfuzz-3.9.0-cp312-cp312-macosx_10_9_universal2.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "c74f2da334ce597f31670db574766ddeaee5d9430c2c00e28d0fbb7f76172036",
-              "url": "https://files.pythonhosted.org/packages/e2/5c/a9d4513e509201f57254abc63d768e3018c0c3014dff8a356489dadd12c6/rapidfuzz-3.9.0-cp311-cp311-musllinux_1_1_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "3c42a238bf9dd48f4ccec4c6934ac718225b00bb3a438a008c219e7ccb3894c7",
-              "url": "https://files.pythonhosted.org/packages/e6/be/c1a371d80cc3fbfd484124ba33f996d6f9916f124772d8f9dd7327c1fb8f/rapidfuzz-3.9.0-cp39-cp39-musllinux_1_1_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "6993d361f28b9ef5f0fa4e79b8541c2f3507be7471b9f9cb403a255e123b31e1",
-              "url": "https://files.pythonhosted.org/packages/ee/3e/2966e77991f76e162d3b25550d38afd942d86811e75eafcb5755e786ec57/rapidfuzz-3.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "849160dc0f128acb343af514ca827278005c1d00148d025e4035e034fc2d8c7f",
-              "url": "https://files.pythonhosted.org/packages/f1/24/a8727b1eb9883e6926ca422043ec935da2c729bc9374996a96147f3fc866/rapidfuzz-3.9.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "7988363b3a415c5194ce1a68d380629247f8713e669ad81db7548eb156c4f365",
-              "url": "https://files.pythonhosted.org/packages/f2/f2/25f0421e3f7557d128818623a4a2930b815c7fb5da35aeae8f9890ee345b/rapidfuzz-3.9.0-cp310-cp310-musllinux_1_1_ppc64le.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "08d8b49b3a4fb8572e480e73fcddc750da9cbb8696752ee12cca4bf8c8220d52",
-              "url": "https://files.pythonhosted.org/packages/f8/0c/7135b9118faccec11704d441b3ed589eda99015848e9859e4be2f5423b21/rapidfuzz-3.9.0-cp310-cp310-musllinux_1_1_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "0e86e39c1c1a0816ceda836e6f7bd3743b930cbc51a43a81bb433b552f203f25",
-              "url": "https://files.pythonhosted.org/packages/f9/bd/150bfc68d01f6e7b4380f8870da73832f45c2657d48694157c63c5c0fe95/rapidfuzz-3.9.0-cp312-cp312-musllinux_1_1_i686.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "c4ef34b2ddbf448f1d644b4ec6475df8bbe5b9d0fee173ff2e87322a151663bd",
-              "url": "https://files.pythonhosted.org/packages/fb/8d/30321c8dffb70aba64d5449404ebd6ba441277f06f475caf0d79e9c5d867/rapidfuzz-3.9.0-cp311-cp311-musllinux_1_1_ppc64le.whl"
+              "hash": "505d99131afd21529293a9a7b91dfc661b7e889680b95534756134dc1cc2cd86",
+              "url": "https://files.pythonhosted.org/packages/fb/d8/b20079cc864ef097827478bf2e3a48d89c37ca1bd69ab810973f0897a145/rapidfuzz-3.9.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             }
           ],
           "project_name": "rapidfuzz",
@@ -2147,19 +2189,19 @@
             "numpy; extra == \"full\""
           ],
           "requires_python": ">=3.8",
-          "version": "3.9.0"
+          "version": "3.9.3"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
-              "url": "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl"
+              "hash": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6",
+              "url": "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1",
-              "url": "https://files.pythonhosted.org/packages/9d/be/10918a2eac4ae9f02f6cfe6414b7a155ccd8f7f9d4380d62fd5b955065c3/requests-2.31.0.tar.gz"
+              "hash": "55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+              "url": "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz"
             }
           ],
           "project_name": "requests",
@@ -2171,25 +2213,102 @@
             "idna<4,>=2.5",
             "urllib3<3,>=1.21.1"
           ],
-          "requires_python": ">=3.7",
-          "version": "2.31.0"
+          "requires_python": ">=3.8",
+          "version": "2.32.3"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "99224d621affbb3c1a4f72b631f8393045f4ce647dd3262f12fe3576918f8bf3",
-              "url": "https://files.pythonhosted.org/packages/e1/7a/835aacf621bb9da635714a0d82cc1f5196257d2ac8b106b9aa2aa7048d67/SQLAlchemy-1.4.52-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "cf270de5a4c5874e84599fc5778303d496c10ae5e870bfa378818f35d21bda5c",
+              "url": "https://files.pythonhosted.org/packages/d7/25/dd878a121fcfdf38f52850f11c512e13ec87c2ea72385933818e5b6c15ce/requests_file-2.1.0-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0f549a3f3b0699415ac04d167e9cb39bccfb730cb832b4d20be3d9867356e658",
+              "url": "https://files.pythonhosted.org/packages/72/97/bf44e6c6bd8ddbb99943baf7ba8b1a8485bcd2fe0e55e5708d7fee4ff1ae/requests_file-2.1.0.tar.gz"
+            }
+          ],
+          "project_name": "requests-file",
+          "requires_dists": [
+            "requests>=1.0.0"
+          ],
+          "requires_python": null,
+          "version": "2.1.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06",
+              "url": "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6",
+              "url": "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz"
+            }
+          ],
+          "project_name": "requests-toolbelt",
+          "requires_dists": [
+            "requests<3.0.0,>=2.0.1"
+          ],
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7",
+          "version": "1.0.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "66c74bee88d09ace46e4fc9c2f6b47c0d012817a764f70a5455d6dc2c7ed635c",
+              "url": "https://files.pythonhosted.org/packages/7d/b3/4c694f266760c0574159654ad1a1f7eb682584d9a3b9552ec24a38f73879/simple_salesforce-1.12.6-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "77590606c781905f6b75430562951dd2b062438da7f55fca2b61e4cde31df15b",
+              "url": "https://files.pythonhosted.org/packages/13/a7/22d3992b8413cb775191a2f7af8b193cdaa9d244bf1613a2affeb26bc9f3/simple-salesforce-1.12.6.tar.gz"
+            }
+          ],
+          "project_name": "simple-salesforce",
+          "requires_dists": [
+            "more-itertools",
+            "pyjwt[crypto]",
+            "requests>=2.22.0",
+            "typing-extensions",
+            "zeep"
+          ],
+          "requires_python": null,
+          "version": "1.12.6"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
+              "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+              "url": "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"
+            }
+          ],
+          "project_name": "six",
+          "requires_dists": [],
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7",
+          "version": "1.16.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "de9acf369aaadb71a725b7e83a5ef40ca3de1cf4cdc93fa847df6b12d3cd924b",
+              "url": "https://files.pythonhosted.org/packages/10/c1/1613a8dcd05e6dacc9505554ce6c217a1cfda0da9c7592e258856945c6b6/SQLAlchemy-1.4.52-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
               "hash": "84e10772cfc333eb08d0b7ef808cd76e4a9a30a725fb62a0495877a57ee41d81",
               "url": "https://files.pythonhosted.org/packages/0d/b9/dd113bfc8032de8234f7d7fee4bd3025fe744d73e81e4d899a609e6e2add/SQLAlchemy-1.4.52-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "de9acf369aaadb71a725b7e83a5ef40ca3de1cf4cdc93fa847df6b12d3cd924b",
-              "url": "https://files.pythonhosted.org/packages/10/c1/1613a8dcd05e6dacc9505554ce6c217a1cfda0da9c7592e258856945c6b6/SQLAlchemy-1.4.52-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -2228,33 +2347,13 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "a551d5f3dc63f096ed41775ceec72fdf91462bb95abdc179010dc95a93957800",
-              "url": "https://files.pythonhosted.org/packages/c9/1d/ce0026b15649667bf96c4de85572d3f2c79cf92b5aba64288b34f4dc60a5/SQLAlchemy-1.4.52-cp39-cp39-macosx_11_0_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "618827c1a1c243d2540314c6e100aee7af09a709bd005bae971686fab6723554",
               "url": "https://files.pythonhosted.org/packages/ce/e6/9da1e081321a514c0147a2e0b293f27ca93f0f299cbd5ba746a9422a9f07/SQLAlchemy-1.4.52-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d2de46f5d5396d5331127cfa71f837cca945f9a2b04f7cb5a01949cf676db7d1",
-              "url": "https://files.pythonhosted.org/packages/dd/2f/b6e8cb74ea2418a1ac4ee911cf13272595490381add8122f3beb40a274df/SQLAlchemy-1.4.52-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "24bb0f81fbbb13d737b7f76d1821ec0b117ce8cbb8ee5e8641ad2de41aa916d3",
               "url": "https://files.pythonhosted.org/packages/ed/8d/0f239be1ac9d34658110db50d2362e52116477660820149ab088221a5f35/SQLAlchemy-1.4.52-cp310-cp310-manylinux1_x86_64.manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_5_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "6ab773f9ad848118df7a9bbabca53e3f1002387cdbb6ee81693db808b82aaab0",
-              "url": "https://files.pythonhosted.org/packages/ee/41/2c4ee7722859c88781cf8bf141ae5e343e872eb00c50c3910b44160b71cb/SQLAlchemy-1.4.52-cp39-cp39-manylinux1_x86_64.manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_5_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "7027be7930a90d18a386b25ee8af30514c61f3852c7268899f23fdfbd3107181",
-              "url": "https://files.pythonhosted.org/packages/f4/50/7a68343d149ed7e7b89de57df7e630177636898497ad25f658b652168b5f/SQLAlchemy-1.4.52-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -2354,31 +2453,31 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a",
-              "url": "https://files.pythonhosted.org/packages/01/f3/936e209267d6ef7510322191003885de524fc48d1b43269810cd589ceaf5/typing_extensions-4.11.0-py3-none-any.whl"
+              "hash": "04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+              "url": "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0",
-              "url": "https://files.pythonhosted.org/packages/f6/f3/b827b3ab53b4e3d8513914586dcca61c355fa2ce8252dea4da56e67bf8f2/typing_extensions-4.11.0.tar.gz"
+              "hash": "1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8",
+              "url": "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.8",
-          "version": "4.11.0"
+          "version": "4.12.2"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d",
-              "url": "https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl"
+              "hash": "a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
+              "url": "https://files.pythonhosted.org/packages/ca/1c/89ffc63a9605b583d5df2be791a27bc1a42b7c32bab68d3c8f2f73a98cd4/urllib3-2.2.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19",
-              "url": "https://files.pythonhosted.org/packages/7a/50/7fd50a27caa0652cd4caf224aa87741ea41d3265ad13f010886167cfcc79/urllib3-2.2.1.tar.gz"
+              "hash": "dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168",
+              "url": "https://files.pythonhosted.org/packages/43/6d/fa469ae21497ddc8bc93e5877702dca7cb8f911e337aca7452b5724f1bb6/urllib3-2.2.2.tar.gz"
             }
           ],
           "project_name": "urllib3",
@@ -2390,7 +2489,7 @@
             "zstandard>=0.18.0; extra == \"zstd\""
           ],
           "requires_python": ">=3.8",
-          "version": "2.2.1"
+          "version": "2.2.2"
         },
         {
           "artifacts": [
@@ -2447,6 +2546,50 @@
           ],
           "requires_python": null,
           "version": "0.2.13"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "6754feb4c34a4b6d65fbc359252bf6654dcce3937bf1d95aae4402a60a8f5939",
+              "url": "https://files.pythonhosted.org/packages/57/49/1091bd708f8892dc2ed5155bdf71ff51fcde75df137d65ac53f5d7f4fa25/zeep-4.2.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "72093acfdb1d8360ed400869b73fbf1882b95c4287f798084c42ee0c1ff0e425",
+              "url": "https://files.pythonhosted.org/packages/fd/a4/8fa2337f1807fd9e671b85980b2c90052d524edf9d39b515aed4c5874c38/zeep-4.2.1.tar.gz"
+            }
+          ],
+          "project_name": "zeep",
+          "requires_dists": [
+            "attrs>=17.2.0",
+            "cached-property>=1.3.0; python_version < \"3.8\"",
+            "coverage[toml]==5.2.1; extra == \"test\"",
+            "flake8-blind-except==0.1.1; extra == \"test\"",
+            "flake8-debugger==3.2.1; extra == \"test\"",
+            "flake8-imports==0.1.1; extra == \"test\"",
+            "flake8==3.8.3; extra == \"test\"",
+            "freezegun==0.3.15; extra == \"test\"",
+            "httpx>=0.15.0; extra == \"async\"",
+            "isodate>=0.5.4",
+            "isort==5.3.2; extra == \"test\"",
+            "lxml>=4.6.0",
+            "platformdirs>=1.4.0",
+            "pretend==1.0.9; extra == \"test\"",
+            "pytest-asyncio; extra == \"test\"",
+            "pytest-cov==2.8.1; extra == \"test\"",
+            "pytest-httpx; extra == \"test\"",
+            "pytest==6.2.5; extra == \"test\"",
+            "pytz",
+            "requests-file>=1.5.1",
+            "requests-mock>=0.7.0; extra == \"test\"",
+            "requests-toolbelt>=0.7.1",
+            "requests>=2.7.0",
+            "sphinx>=1.4.0; extra == \"docs\"",
+            "xmlsec>=0.6.1; extra == \"xmlsec\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "4.2.1"
         }
       ],
       "platform_tag": null
@@ -2464,10 +2607,11 @@
     "pydantic",
     "pytest",
     "python-Levenshtein",
+    "simple-salesforce",
     "uszipcode"
   ],
   "requires_python": [
-    ">=3.9"
+    ">=3.10"
   ],
   "resolver_version": "pip-2020-resolver",
   "style": "universal",

--- a/pants.toml
+++ b/pants.toml
@@ -13,3 +13,4 @@ enabled = false
 interpreter_constraints = [">=3.10"]
 enable_resolves = true
 resolves = { python-default = "default.lock" }
+resolves_to_constraints_file = { python-default = "constraints.txt" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ uszipcode
 python-Levenshtein
 pydantic
 pytest
+simple-salesforce

--- a/src/mailchimp_entry.py
+++ b/src/mailchimp_entry.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -22,8 +20,8 @@ class MailchimpEntry(BaseModel):
     def mock(
         cls,
         *,
-        latitude: Optional[str] = None,
-        longitude: Optional[str] = None,
+        latitude: str | None = None,
+        longitude: str | None = None,
     ) -> "MailchimpEntry":
         return cls(
             **{

--- a/src/main.py
+++ b/src/main.py
@@ -7,15 +7,14 @@ from uszipcode import SearchEngine
 import metro_csvs
 from mailchimp_entry import MailchimpEntry
 from salesforce_entry import SalesforceEntry
+from salesforce_api import load_salesforce_data
 
 
 def main() -> None:
-    with Path("data/salesforce.csv").open() as f:
-        entries = [SalesforceEntry(**row) for row in csv.DictReader(f)]
-    with Path("data/mailchimp.csv").open() as f:
-        mailchimp_by_email = {
-            row["Email Address"]: MailchimpEntry(**row) for row in csv.DictReader(f)
-        }
+    entries = load_salesforce_data()
+
+    # TODO: read in Mailchimp data
+    mailchimp_by_email = {}
 
     us_zip_to_metro = metro_csvs.read_us_zip_to_metro()
     us_city_and_state_to_metro = metro_csvs.read_us_city_and_state_to_metro()

--- a/src/salesforce_api.py
+++ b/src/salesforce_api.py
@@ -1,0 +1,18 @@
+import os
+
+from simple_salesforce import Salesforce
+
+from salesforce_entry import SalesforceEntry
+
+
+INSTANCE_URL = os.environ.pop("SALESFORCE_INSTANCE_URL")
+TOKEN = os.environ.pop("SALESFORCE_TOKEN")
+sf = Salesforce(instance_url=INSTANCE_URL, session_id=TOKEN)
+
+
+def load_salesforce_data() -> list[SalesforceEntry]:
+    fields = ", ".join(info.alias for info in SalesforceEntry.model_fields.values())
+    return [
+        SalesforceEntry(**raw)
+        for raw in sf.query_all_iter(f"SELECT {fields} FROM Contact")
+    ]

--- a/src/salesforce_entry.py
+++ b/src/salesforce_entry.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from geopy import Nominatim
 from uszipcode import SearchEngine
 from pydantic import BaseModel, Field
@@ -9,41 +7,41 @@ from state_codes import US_STATES_TO_CODES
 
 
 class SalesforceEntry(BaseModel):
-    email: str = Field(..., alias="Email", frozen=True)
     uid: str = Field(..., alias="Id", frozen=True)
-    city: str = Field(..., alias="MailingCity")
-    country: str = Field(..., alias="MailingCountry")
-    latitude: str = Field(..., alias="MailingLatitude")
-    longitude: str = Field(..., alias="MailingLongitude")
-    zipcode: str = Field(..., alias="MailingPostalCode")
-    state: str = Field(..., alias="MailingState")
-    street: str = Field(..., alias="MailingStreet")
-    metro: str = Field("", alias="MetropolitanArea")
+    email: str | None = Field(..., alias="Email", frozen=True)
+    city: str | None = Field(..., alias="MailingCity")
+    country: str | None = Field(..., alias="MailingCountry")
+    latitude: str | None = Field(..., alias="MailingLatitude")
+    longitude: str | None = Field(..., alias="MailingLongitude")
+    zipcode: str | None = Field(..., alias="MailingPostalCode")
+    state: str | None = Field(..., alias="MailingState")
+    street: str | None = Field(..., alias="MailingStreet")
+    metro: str | None = Field(..., alias="Metro_Area__c")
 
     @classmethod
     def mock(
         cls,
         *,
-        city: Optional[str] = None,
-        country: Optional[str] = None,
-        latitude: Optional[str] = None,
-        longitude: Optional[str] = None,
-        zipcode: Optional[str] = None,
-        state: Optional[str] = None,
-        street: Optional[str] = None,
-        metro: Optional[str] = None,
+        city: str | None = None,
+        country: str | None = None,
+        latitude: str | None = None,
+        longitude: str | None = None,
+        zipcode: str | None = None,
+        state: str | None = None,
+        street: str | None = None,
+        metro: str | None = None,
     ) -> "SalesforceEntry":
         return cls(
             Email="tech@parkingreform.org",
             Id="12345",
-            MailingCity=city or "",
-            MailingCountry=country or "",
-            MailingLatitude=latitude or "",
-            MailingLongitude=longitude or "",
-            MailingPostalCode=zipcode or "",
-            MailingState=state or "",
-            MailingStreet=street or "",
-            MetropolitanArea=metro or "",
+            MailingCity=city,
+            MailingCountry=country,
+            MailingLatitude=latitude,
+            MailingLongitude=longitude,
+            MailingPostalCode=zipcode,
+            MailingState=state,
+            MailingStreet=street,
+            Metro_Area__c=metro,
         )
 
     def normalize(self) -> None:
@@ -55,26 +53,29 @@ class SalesforceEntry(BaseModel):
             self.country = "USA"
 
         # Convert US state names to two-digit codes.
-        if self.country == "USA" and len(self.state) > 2:
+        if self.country == "USA" and self.state and len(self.state) > 2:
+            if self.state not in US_STATES_TO_CODES:
+                raise ValueError(f"Unrecognized state {self.state} for {self.uid}")
             self.state = US_STATES_TO_CODES[self.state]
 
         # Lowercase all-caps city names.
-        if self.city.isupper():
+        if self.city and self.city.isupper():
             self.city = self.city.title()
 
         # Normalize US zip codes to be 5 digits.
-        if self.country == "USA" and len(self.zipcode) > 5:
+        if self.country == "USA" and self.zipcode and len(self.zipcode) > 5:
             if self.zipcode[5] != "-":
                 raise AssertionError(f"Unexpected zipcode for {self}")
             self.zipcode = self.zipcode[:5]
 
     def populate_via_latitude_longitude(
-        self, mailchimp: Optional[MailchimpEntry], geocoder: Nominatim
+        self, mailchimp: MailchimpEntry | None, geocoder: Nominatim
     ) -> None:
         mailchimp_missing = mailchimp is None or not (
             mailchimp.latitude and mailchimp.longitude
         )
-        if self.zipcode or mailchimp_missing:
+        metro_area_can_be_computed = self.zipcode or (self.city and self.country)
+        if mailchimp_missing or metro_area_can_be_computed:
             return
 
         addr = geocoder.reverse(f"{mailchimp.latitude}, {mailchimp.longitude}").raw[
@@ -90,9 +91,9 @@ class SalesforceEntry(BaseModel):
         # Also overwrite any existing values so that we don't mix the prior address
         # with the new one.
         self.street = None
-        self.country = addr.get("country_code", "").upper()
-        self.state = addr.get("state", "")
-        self.city = addr.get("city", "")
+        self.country = addr.get("country_code", "").upper() or None
+        self.state = addr.get("state")
+        self.city = addr.get("city")
 
     def populate_via_zipcode(self, zipcode_search_engine: SearchEngine) -> None:
         """Look up city and state for US zip codes."""
@@ -109,7 +110,6 @@ class SalesforceEntry(BaseModel):
     ) -> None:
         if self.country != "USA":
             return
-        metro = us_zip_to_metro.get(self.zipcode) or us_city_and_state_to_metro.get(
-            (self.city, self.state)
-        )
-        self.metro = metro or ""
+        self.metro = us_zip_to_metro.get(
+            self.zipcode
+        ) or us_city_and_state_to_metro.get((self.city, self.state))

--- a/src/salesforce_entry_test.py
+++ b/src/salesforce_entry_test.py
@@ -67,7 +67,7 @@ def test_normalize_city_capitalization(arg: str, expected: str) -> None:
     [
         ("USA", "11370-2314", "11370"),
         ("USA", "11370", "11370"),
-        ("USA", "", ""),
+        ("USA", None, None),
         ("MEX", "11370-54", "11370-54"),
     ],
 )
@@ -81,7 +81,7 @@ def test_normalize_zip_code_length(country: str, zip: str, expected: str) -> Non
     "country,zip,expected_state,expected_city",
     [
         ("USA", "11370", "NY", "East Elmhurst"),
-        ("MEX", "11370", "", ""),
+        ("MEX", "11370", None, None),
     ],
 )
 def test_populate_via_zipcode(
@@ -109,10 +109,10 @@ def test_populate_via_lat_long(geocoder_mock) -> None:
     "country,zip,city,state,expected",
     [
         ("USA", "11370", "Flushing", "NY", "My Metro"),
-        ("USA", "99999", "Flushing", "NY", ""),
-        ("USA", "", "Tempe", "AZ", "My Metro"),
-        ("USA", "", "", "", ""),
-        ("MEX", "11370", "Tempe", "AZ", ""),
+        ("USA", "99999", "Flushing", "NY", None),
+        ("USA", None, "Tempe", "AZ", "My Metro"),
+        ("USA", None, None, None, None),
+        ("MEX", "11370", "Tempe", "AZ", None),
     ],
 )
 def test_populate_metro_area(


### PR DESCRIPTION
Before, the member data had to be loaded via a CSV that we manually exported. Now, we dynamically read in the data through the Salesforce REST API and the helper library https://github.com/simple-salesforce/simple-salesforce.

A follow-up will save the results to Salesforce.

For now, I turned off Mailchimp data. Our CSV is out-of-date and all those entries were already processed and saved in Salesforce a while ago.

Note that Salesforce stores unset values as `None`, rather than `""`, so we change `SalesforceEntry` to better model unset values.