### PR TITLE
Compute which entries have been changed

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import csv
+import logging
 from pathlib import Path
 
 from geopy import Nominatim
@@ -7,6 +8,9 @@ from uszipcode import SearchEngine
 import metro_csvs
 from mailchimp_entry import MailchimpEntry
 from salesforce_api import init_salesforce_client, load_salesforce_data
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
 
 
 def main() -> None:
@@ -21,7 +25,10 @@ def main() -> None:
     zipcode_search_engine = SearchEngine()
     geocoder = Nominatim(user_agent="parking_reform_network_data_enrichment")
 
+    uid_to_changes: dict[str, dict[str, str]] = {}
     for entry in entries:
+        original_model_dump = entry.model_dump(by_alias=True)
+
         # The order of operations matters.
         if entry.email:
             entry.populate_via_latitude_longitude(
@@ -30,6 +37,13 @@ def main() -> None:
         entry.normalize()
         entry.populate_via_zipcode(zipcode_search_engine)
         entry.populate_metro_area(us_zip_to_metro, us_city_and_state_to_metro)
+
+        changes = entry.compute_changes(original_model_dump)
+        if changes:
+            logger.info(f"Changes made to {entry.uid}: {sorted(changes.keys())}")
+            uid_to_changes[entry.uid] = changes
+
+    logger.info(f"Total changes made: {len(uid_to_changes)}")
 
     with Path("data/result.csv").open("w", newline="") as f:
         result = [entry.model_dump(by_alias=True) for entry in entries]

--- a/src/salesforce_entry.py
+++ b/src/salesforce_entry.py
@@ -44,6 +44,10 @@ class SalesforceEntry(BaseModel):
             Metro_Area__c=metro,
         )
 
+    def compute_changes(self, original_model_dump: dict[str, str]) -> dict[str, str]:
+        new_model_dump = self.model_dump(by_alias=True)
+        return {k: v for k, v in new_model_dump.items() if v != original_model_dump[k]}
+
     def normalize(self) -> None:
         """Normalize the country code, state, city, and zip.
 

--- a/src/salesforce_entry_test.py
+++ b/src/salesforce_entry_test.py
@@ -121,3 +121,21 @@ def test_populate_metro_area(
     entry = SalesforceEntry.mock(country=country, zipcode=zip, city=city, state=state)
     entry.populate_metro_area({"11370": "My Metro"}, {("Tempe", "AZ"): "My Metro"})
     assert entry.metro == expected
+
+
+def test_compute_changes() -> None:
+    entry = SalesforceEntry.mock()
+    original_model_dump = entry.model_dump(by_alias=True)
+
+    assert not entry.compute_changes(original_model_dump)
+
+    entry.city = "My City"
+    entry.zipcode = "11370"
+    updates = {"MailingCity": "My City", "MailingPostalCode": "11370"}
+    assert entry.compute_changes(original_model_dump) == updates
+    updated_model_dump = entry.model_dump(by_alias=True)
+
+    entry.country = "USA"
+    country_update = {"MailingCountry": "USA"}
+    assert entry.compute_changes(original_model_dump) == {**updates, **country_update}
+    assert entry.compute_changes(updated_model_dump) == country_update


### PR DESCRIPTION
This allows us to update only the exact entries and fields that have been changed, which reduces risk and reduces API calls.

This PR also sets up logging.