### PR TITLE
Write results to Salesforce

### DIFF
--- a/src/salesforce_api.py
+++ b/src/salesforce_api.py
@@ -5,13 +5,13 @@ from simple_salesforce import Salesforce
 from salesforce_entry import SalesforceEntry
 
 
-def init_salesforce_client() -> Salesforce:
+def init_client() -> Salesforce:
     INSTANCE_URL = os.environ.pop("SALESFORCE_INSTANCE_URL")
     TOKEN = os.environ.pop("SALESFORCE_TOKEN")
     return Salesforce(instance_url=INSTANCE_URL, session_id=TOKEN)
 
 
-def load_salesforce_data(client: Salesforce) -> list[SalesforceEntry]:
+def load_data(client: Salesforce) -> list[SalesforceEntry]:
     fields = ", ".join(
         info.alias or name for name, info in SalesforceEntry.model_fields.items()
     )
@@ -19,3 +19,10 @@ def load_salesforce_data(client: Salesforce) -> list[SalesforceEntry]:
         SalesforceEntry(**raw)
         for raw in client.query_all_iter(f"SELECT {fields} FROM Contact")
     ]
+
+
+def write_changes(
+    client: Salesforce, uid_to_changes: dict[str, dict[str, str]]
+) -> None:
+    for uid, changes in uid_to_changes.items():
+        client.Contact.update(uid, changes)  # type: ignore[operator]


### PR DESCRIPTION
We don't write by default unless you specify `--write`.

We don't use the Bulk API because our # of expected records updates is low and the Bulk API is more complex.