### PR TITLE
Eagerly write updates to Salesforce

### DIFF
--- a/src/salesforce_api.py
+++ b/src/salesforce_api.py
@@ -27,8 +27,5 @@ def load_data(client: Salesforce) -> list[SalesforceEntry]:
     ]
 
 
-def write_changes(
-    client: Salesforce, uid_to_changes: dict[str, dict[str, str]]
-) -> None:
-    for uid, changes in uid_to_changes.items():
-        client.Contact.update(uid, changes)  # type: ignore[operator]
+def write_change(client: Salesforce, uid: str, changes: dict[str, str]) -> None:
+    client.Contact.update(uid, changes)  # type: ignore[operator]

--- a/src/state_codes.py
+++ b/src/state_codes.py
@@ -10,6 +10,7 @@ US_STATES_TO_CODES = {
     "District of Columbia": "DC",
     "Florida": "FL",
     "Georgia": "GA",
+    "Guam": "GU",
     "Hawaii": "HI",
     "Idaho": "ID",
     "Illinois": "IL",


### PR DESCRIPTION
I was about 800 records through updates when the program crashed because of an unrecognized state code. This is the second time a crash has happened. The issue is that none of the prior changes are saved in this case, so we have to rerun the entire program from the start.

Now, the program eagerly writes updates when they are computed. Even if we crash on record 1000, the first 999 will have been written.